### PR TITLE
Add conditional to set _mv variable to np.uint64 data type

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -108,13 +108,13 @@ First, clone pyflwdir's ``git`` repo and navigate into the repository:
     $ git clone git@github.com:Deltares/pyflwdir.git
     $ cd pyflwdir
 
-Then, make and activate a new pyflwdir conda environment based on the environment.yml
+Then, make and activate a new pyflwdir conda environment based on the `environment.yml`
 file contained in the repository:
 
 .. code-block:: console
 
-    $ conda env create -f envs/pyflwdir-dev.yml
-    $ conda activate pyflwdir-dev
+    $ conda env create -f environment.yml
+    $ conda activate pyflwdir
 
 Finally, build and install PyFlwDir:
 

--- a/pyflwdir/flwdir.py
+++ b/pyflwdir/flwdir.py
@@ -81,10 +81,12 @@ class Flwdir(object):
         self.idxs_outlet = idxs_outlet
         self._seq = idxs_seq
         self._nnodes = nnodes
-        # either -1 for int or 4294967295 for uint32
+        # either -1 for int, 4294967295 for uint32, or 18446744073709551615 for uint64
         self._mv = core._mv
         if idxs_ds.dtype == np.uint32:
             self._mv = np.uint32(self._mv)
+        if idxs_ds.dtype == np.uint64:
+            self._mv = np.uint64(self._mv)
 
         # set placeholders only used if cache if True
         self.cache = cache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,8 +80,35 @@ def test_data1(flwdir1_idxs, flwdir1_rank):
 
 
 @pytest.fixture(scope="session")
-def test_data(test_data0, flwdir0, test_data1, flwdir1):
-    return [(test_data0, flwdir0), (test_data1, flwdir1)]
+def flwdir2():
+    np.random.seed(2345)
+    return from_dem(np.random.rand(15, 10)).to_array("d8")
+
+
+@pytest.fixture(scope="session")
+def flwdir2_idxs(flwdir2):
+    idxs_ds2, idxs_pit2, _ = core_d8.from_array(flwdir2, dtype=np.uint64)
+    return idxs_ds2, idxs_pit2
+
+
+@pytest.fixture(scope="session")
+def flwdir2_rank(flwdir2_idxs):
+    idxs_ds2, _ = flwdir2_idxs
+    rank2, n2 = core.rank(idxs_ds2, mv=np.uint64(core._mv))
+    seq2 = np.argsort(rank2)[-n2:]
+    return rank2, n2, seq2
+
+
+@pytest.fixture(scope="session")
+def test_data2(flwdir2_idxs, flwdir2_rank):
+    rank2, _, seq2 = flwdir2_rank
+    idxs_ds2, idxs_pit2 = flwdir2_idxs
+    return idxs_ds2, idxs_pit2, seq2, rank2, np.uint64(core._mv)
+
+
+@pytest.fixture(scope="session")
+def test_data(test_data0, flwdir0, test_data1, flwdir1, test_data2, flwdir2):
+    return [(test_data0, flwdir0), (test_data1, flwdir1), (test_data2, flwdir2)]
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_pyflwdir.py
+++ b/tests/test_pyflwdir.py
@@ -49,7 +49,8 @@ def test_flwdirraster_errors(flwdir0, flwdir0_idxs):
 
 
 @pytest.mark.parametrize(
-    "test_data, flwdir", [("test_data0", "flwdir0"), ("test_data1", "flwdir1")]
+    "test_data, flwdir",
+    [("test_data0", "flwdir0"), ("test_data1", "flwdir1"), ("test_data2", "flwdir2")],
 )
 def test_flwdirraster_attrs(test_data, flwdir, request):
     d8 = request.getfixturevalue(flwdir)


### PR DESCRIPTION
Allow the processing of large rasters, shaped at (63708, 79780), for `Flwdir` object. 

## Issue addressed
Closes #46

## Explanation
As described in issue #46, when large rasters are used, an IndexError was thrown from underlying numba code.

The [upstream_count](https://github.com/Deltares/pyflwdir/blob/45c5e63615a9919af9c7ea9719c3dde4f975d425/pyflwdir/core.py#L51) function was the cause of the Indexing Error, due to an incorrect value set in the `_mv` variable when using a `np.uint64` data type.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [x] Updated CHANGELOG.rst if needed

## Additional Notes (optional)
The setting of the np.uint64  dtype in [pyflwdir.py](https://github.com/Deltares/pyflwdir/blob/main/pyflwdir/pyflwdir.py#L167) was not accounted for, and caused non-correct values in the `_mv` variable, when assigned in [core.py](https://github.com/Deltares/pyflwdir/blob/45c5e63615a9919af9c7ea9719c3dde4f975d425/pyflwdir/core.py#L12). This was causing the C pointer references to not line up with the signed integer type that was being used in python. See [numpy docs](https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.intp) for `np.intp()`

The downstream effects 
