### PR TITLE
Fix typo in quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -43,7 +43,7 @@ Vectorize the stream network and save to a geojson file:
 
     import geopandas as gpd
     feat = flw.streams()
-    gdf = gpd.GeoDataFrame.from_features(feats, crs=crs)
+    gdf = gpd.GeoDataFrame.from_features(feat, crs=crs)
     gdf.to_file('streams.geojson', driver='GeoJSON')
 
 


### PR DESCRIPTION
In the Quickstart section of the documentation, the variable returned by `flw.streams()` was accidentally referred to as `feats`. This PR renames it to `feat` so that the snippet reads:

```python
feat = flw.streams()
gdf = gpd.GeoDataFrame.from_features(feat, crs=crs)

