### PR TITLE
Fix: On Mac, creating boolean arrays with list comprehensions seem to fail sometimes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ in development
 ********************
 * add conversion methods to api refs (#65)
 * add section to upscaling example to save output to file (#73)
+* use numpy array to create boolean rather than list comprehension, fixing an issue for Mac (#76)
 
 0.5.10  (18-02-2025)
 ********************

--- a/pyflwdir/basins.py
+++ b/pyflwdir/basins.py
@@ -52,7 +52,7 @@ def interbasin_mask(idxs_ds, seq, region, stream=None):
             if mask[idx0]:
                 mask[idxs_ds[idx0]] = True
     else:
-        mask = np.array([bool(1) for _ in range(region.size)])  # all True
+        mask = np.ones(region.size, dtype=np.bool_)
     # keep only the most downstream contiguous area within region
     for idx0 in seq:  # down- to upstream
         idx_ds = idxs_ds[idx0]

--- a/pyflwdir/core.py
+++ b/pyflwdir/core.py
@@ -485,7 +485,7 @@ def snap(
 def inflow_idxs(idxs_ds, seq, region):
     """returns linear indices of most upstream cells within region"""
     idxs = []
-    mask = np.array([bool(1) for _ in range(idxs_ds.size)])  # all True
+    mask = np.ones(idxs_ds.size, dtype=np.bool_)
     for idx0 in seq[::-1]:  # up- to downstream
         idx_ds = idxs_ds[idx0]
         if idx0 != idx_ds:
@@ -502,7 +502,7 @@ def inflow_idxs(idxs_ds, seq, region):
 def outflow_idxs(idxs_ds, seq, region):
     """returns linear indices of most downstream cells within region"""
     idxs = []
-    mask = np.array([bool(1) for _ in range(idxs_ds.size)])  # all True
+    mask = np.ones(idxs_ds.size, dtype=np.bool_)
     for idx0 in seq:  # down- to upstream
         idx_ds = idxs_ds[idx0]
         # at mask and region and (pit or out)

--- a/pyflwdir/dem.py
+++ b/pyflwdir/dem.py
@@ -154,7 +154,7 @@ def adjust_elevation(idxs_ds, seq, elevtn, mv=_mv):
     2012.
     """
     elevtn_out = elevtn.copy()
-    mask = np.array([bool(0) for _ in range(elevtn.size)])  # True for checked cells
+    mask = np.zeros(idxs_ds.size, dtype=np.bool_)
     for idx0 in seq[::-1]:  # from up- to downstream starting from longest stream paths
         if mask[idx0] == False:  # @ head water cell
             # get downstream indices up to earlier fixed stream path

--- a/pyflwdir/streams.py
+++ b/pyflwdir/streams.py
@@ -154,7 +154,7 @@ def streams(idxs_ds, seq, mask=None, max_len=0, mv=core._mv):
     nup = core.upstream_count(idxs_ds=idxs_ds, mask=mask, mv=mv)
     # get list of indices arrays of segments
     streams = []
-    done = np.array([bool(0) for _ in range(idxs_ds.size)])  # all False
+    done = np.zeros(idxs_ds.size, dtype=np.bool_)
     for idx0 in seq[::-1]:  # up- to downstream
         if done[idx0] or (mask is not None and ~mask[idx0]):
             continue

--- a/pyflwdir/subgrid.py
+++ b/pyflwdir/subgrid.py
@@ -177,7 +177,7 @@ def segment_length(
         channel section length [m]
     """
     # temp binary array with outlets
-    outlets = np.array([bool(0) for _ in range(idxs_nxt.size)])
+    outlets = np.zeros(idxs_nxt.size, dtype=np.bool_)
     for idx0 in idxs_out:
         if idx0 != mv:
             outlets[idx0] = bool(1)
@@ -240,7 +240,7 @@ def segment_average(
         segment mean value [m]
     """
     # temp binary array with outlets
-    outlets = np.array([bool(0) for _ in range(idxs_nxt.size)])
+    outlets = np.zeros(idxs_nxt.size, dtype=np.bool_)
     for idx0 in idxs_out:
         if idx0 != mv:
             outlets[idx0] = bool(1)
@@ -305,7 +305,7 @@ def segment_median(
         segment median value [m]
     """
     # temp binary array with outlets
-    outlets = np.array([bool(0) for _ in range(idxs_nxt.size)])
+    outlets = np.zeros(idxs_nxt.size, dtype=np.bool_)
     for idx0 in idxs_out:
         if idx0 != mv:
             outlets[idx0] = bool(1)
@@ -373,7 +373,7 @@ def segment_indices(
         linear indices of streams
     """
     # temp binary array with outlets
-    outlets = np.array([bool(0) for _ in range(idxs_nxt.size)])
+    outlets = np.zeros(idxs_nxt.size, dtype=np.bool_)
     for idx0 in idxs_out:
         if idx0 != mv:
             outlets[idx0] = bool(1)
@@ -446,7 +446,7 @@ def segment_slope(
         channel section slope [m]
     """
     # temp binary array with outlets
-    outlets = np.array([bool(0) for _ in range(idxs_nxt.size)])
+    outlets = np.zeros(idxs_nxt.size, dtype=np.bool_)
     for idx0 in idxs_out:
         if idx0 != mv:
             outlets[idx0] = bool(1)

--- a/pyflwdir/upscale.py
+++ b/pyflwdir/upscale.py
@@ -1335,7 +1335,7 @@ def upscale_error(subidxs_out, idxs_ds, subidxs_ds, mv=_mv):
     assert subidxs_out.size == idxs_ds.size
     # binary array with outlets
     subn = subidxs_ds.size
-    outlets = np.array([bool(0) for _ in range(subn)])
+    outlets = np.zeros(subn, dtype=np.bool_)
     for subidx in subidxs_out:
         if subidx == mv:
             continue
@@ -1368,7 +1368,7 @@ def upscale_check(subidxs_out, idxs_ds, subidxs_ds, minlen=0, mv=_mv):
     # array with outlets (>=0) and streams (-1); nodata value is -9
     assert subidxs_out.size <= 2147483648
     streams = np.full(subidxs_ds.size, -9, dtype=np.int32)
-    valid = np.array([bool(1) for _ in range(idxs_ds.size)])
+    valid = np.ones(idxs_ds.size, dtype=np.bool_)
     for idx in range(subidxs_out.size):
         subidx = subidxs_out[idx]
         if subidx == mv:

--- a/pyflwdir/upscale.py
+++ b/pyflwdir/upscale.py
@@ -1368,7 +1368,7 @@ def upscale_check(subidxs_out, idxs_ds, subidxs_ds, minlen=0, mv=_mv):
     # array with outlets (>=0) and streams (-1); nodata value is -9
     assert subidxs_out.size <= 2147483648
     streams = np.full(subidxs_ds.size, -9, dtype=np.int32)
-    valid = np.array([bool(1) for _ in range(idxs_ds.size)])
+    valid = np.ones(idxs_ds.size, dtype=np.bool_)
     for idx in range(subidxs_out.size):
         subidx = subidxs_out[idx]
         if subidx == mv:

--- a/pyflwdir/upscale.py
+++ b/pyflwdir/upscale.py
@@ -1335,7 +1335,7 @@ def upscale_error(subidxs_out, idxs_ds, subidxs_ds, mv=_mv):
     assert subidxs_out.size == idxs_ds.size
     # binary array with outlets
     subn = subidxs_ds.size
-    outlets = np.array([bool(0) for _ in range(subn)])
+    outlets = np.zeros(shape=subn, dtype=np.bool_)
     for subidx in subidxs_out:
         if subidx == mv:
             continue


### PR DESCRIPTION
## Issue addressed
Fixes #76

## Explanation
On Mac, using list comprehensions to create boolean arrays fails (see issue). Throughout the code I replace this with numpy-style constructors.

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed
- [x] Updated CHANGELOG.rst if needed

## Additional Notes (optional)
-
