### PR TITLE
Enable numba caching

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ in development
 * add conversion methods to api refs (#65)
 * add section to upscaling example to save output to file (#73)
 * use numpy array to create boolean rather than list comprehension, fixing an issue for Mac (#76)
+* Add Numba caching to improve startup performance (#78)
 
 0.5.10  (18-02-2025)
 ********************

--- a/pyflwdir/arithmetics.py
+++ b/pyflwdir/arithmetics.py
@@ -13,7 +13,7 @@ __all__ = []
 
 # NOTE np.average (with) weights is not yet supoorted by numpy
 # all functions are faster than numpy.
-@njit
+@njit(cache=True)
 def _average(data, weights, nodata):
     """Weighted arithmetic mean"""
     v = 0.0
@@ -29,7 +29,7 @@ def _average(data, weights, nodata):
     return v / w if w != 0 else nodata
 
 
-@njit
+@njit(cache=True)
 def _mean(data, nodata):
     """Arithmetic mean"""
     v = 0.0
@@ -43,7 +43,7 @@ def _mean(data, nodata):
     return v / w if w != 0 else nodata
 
 
-@njit
+@njit(cache=True)
 def lstsq(x: np.ndarray, y: np.ndarray):
     """Simple ordinary Least Squares regression."""
     n = x.size
@@ -64,7 +64,7 @@ def lstsq(x: np.ndarray, y: np.ndarray):
     return slope, intercept
 
 
-@njit
+@njit(cache=True)
 def moving_average(
     data, weights, n, idxs_ds, idxs_us_main, strord=None, nodata=-9999.0, mv=_mv
 ):
@@ -103,7 +103,7 @@ def moving_average(
     return data_out
 
 
-@njit
+@njit(cache=True)
 def moving_median(data, n, idxs_ds, idxs_us_main, strord=None, nodata=-9999.0, mv=_mv):
     """Take the moving median over the flow direction network.
 
@@ -143,7 +143,7 @@ def moving_median(data, n, idxs_ds, idxs_us_main, strord=None, nodata=-9999.0, m
     return data_out
 
 
-@njit
+@njit(cache=True)
 def upstream_sum(idxs_ds, data, nodata=-9999.0, mv=_mv):
     """Returns sum of first upstream values
 

--- a/pyflwdir/basins.py
+++ b/pyflwdir/basins.py
@@ -21,7 +21,7 @@ def basins(idxs_ds, idxs_pit, seq, ids=None):
 # NOTE not unit tested
 # TODO: change this method to derive the interbasin for a single outflow as currently
 # its results are ambiguous?!
-@njit
+@njit(cache=True)
 def interbasin_mask(idxs_ds, seq, region, stream=None):
     """Returns most downstream contiguous area within region, i.e.: if a stream flows
     in and out of the region, only the most downstream contiguous area within region
@@ -64,7 +64,7 @@ def interbasin_mask(idxs_ds, seq, region, stream=None):
     return np.logical_and(mask, region)
 
 
-@njit
+@njit(cache=True)
 def subbasins_streamorder(idxs_ds, seq, strord, mask=None, min_sto=-2):
     """Returns a subbasin map with unique IDs starting from one.
     Subbasins are defined based on a minimum stream order.
@@ -103,7 +103,7 @@ def subbasins_streamorder(idxs_ds, seq, strord, mask=None, min_sto=-2):
     return core.fillnodata_upstream(idxs_ds, seq, subbas, 0), idxs1
 
 
-@njit
+@njit(cache=True)
 def _tributaries(idxs_ds, seq, strord):
     idxs_trib = []
     for idx0 in seq:  # down- to upstream
@@ -113,7 +113,7 @@ def _tributaries(idxs_ds, seq, strord):
     return np.array(idxs_trib, idxs_ds.dtype)
 
 
-@njit
+@njit(cache=True)
 def subbasins_pfafstetter(
     idxs_pit, idxs_ds, seq, idxs_us_main, uparea, mask=None, depth=1, mv=_mv
 ):
@@ -191,7 +191,7 @@ def subbasins_pfafstetter(
     return pfafbas, idxs1
 
 
-@njit
+@njit(cache=True)
 def subbasins_area(idxs_ds, seq, idxs_us_main, uparea, area_min):
     """Returns map with basin IDs, with a minimal area of `area_min`.
     Moving upstream from the basin outlets a new subbasin starts at tributaries

--- a/pyflwdir/core.py
+++ b/pyflwdir/core.py
@@ -14,7 +14,7 @@ _mv = np.intp(-1)
 # flwdir properties
 
 
-@njit
+@njit(cache=True)
 def rank(idxs_ds, mv=_mv):
     """Returns the rank, i.e. the distance counted in number of cells from the outlet."""
     ranks = np.full(idxs_ds.size, -9999, dtype=np.int32)
@@ -47,7 +47,7 @@ def rank(idxs_ds, mv=_mv):
     return ranks, n
 
 
-@njit
+@njit(cache=True)
 def upstream_count(idxs_ds, mv=_mv, mask=None):
     """Returns array with number of upstream cells per cell."""
     n_up = np.full(idxs_ds.size, -9, dtype=np.int8)
@@ -64,7 +64,7 @@ def upstream_count(idxs_ds, mv=_mv, mask=None):
 # returns 2D array (n, d) with indices
 
 
-@njit
+@njit(cache=True)
 def upstream_matrix(idxs_ds, mv=_mv):
     """Returns a 2D array with upstream cell indices for each cell.
     The shape of the array is (idxs_ds.size, max number of upstream cells per cell).
@@ -84,7 +84,7 @@ def upstream_matrix(idxs_ds, mv=_mv):
     return idxs_us
 
 
-@njit
+@njit(cache=True)
 def idxs_seq(idxs_ds, idxs_pit, mv=_mv):
     """Returns indices ordered from down- to upstream.
 
@@ -117,7 +117,7 @@ def idxs_seq(idxs_ds, idxs_pit, mv=_mv):
     return idxs_seq[:i]
 
 
-@njit
+@njit(cache=True)
 def fillnodata_upstream(idxs_ds, seq, data, nodata):
     """Retuns a a copy of <data> where upstream cell with <nodata> values are filled
     based on the first downstream valid cell value.
@@ -146,7 +146,7 @@ def fillnodata_upstream(idxs_ds, seq, data, nodata):
     return data_out
 
 
-@njit
+@njit(cache=True)
 def fillnodata_downstream(idxs_ds, seq, data, nodata, how="max"):
     """Retuns a a copy of <data> where downstream cells with <nodata> values are filled
     based on the first upstream valid cell value.
@@ -188,7 +188,7 @@ def fillnodata_downstream(idxs_ds, seq, data, nodata, how="max"):
     return data_out
 
 
-@njit
+@njit(cache=True)
 def main_upstream(idxs_ds, uparea, upa_min=0.0, mv=_mv):
     """Returns the index of the upstream cell with the largest uparea,
     -1 if no upstream cells (i.e. at headwater).
@@ -222,7 +222,7 @@ def main_upstream(idxs_ds, uparea, upa_min=0.0, mv=_mv):
 # returns 1D array (size < n) with indices of specific locations
 
 
-@njit
+@njit(cache=True)
 def pit_indices(idxs_ds):
     """Returns pit indices, i.e. cells with no downstream cell"""
     idx_lst = []
@@ -232,7 +232,7 @@ def pit_indices(idxs_ds):
     return np.array(idx_lst, dtype=idxs_ds.dtype)
 
 
-@njit
+@njit(cache=True)
 def loop_indices(idxs_ds, mv=_mv):
     """Returns indices loop cells, i.e. cells which do not have a pit at its most"""
     idxs = []
@@ -243,21 +243,21 @@ def loop_indices(idxs_ds, mv=_mv):
     return np.array(idxs, dtype=idxs_ds.dtype)
 
 
-@njit
+@njit(cache=True)
 def headwater_indices(idxs_ds, mask=None, mv=_mv):
     """Returns indices of headwater cells, i.e. cells with no upstream neighbors"""
     nup = upstream_count(idxs_ds, mask=mask, mv=mv)
     return np.where(nup == 0)[0].astype(idxs_ds.dtype)
 
 
-@njit
+@njit(cache=True)
 def confluence_indices(idxs_ds, mask=None, mv=_mv):
     """Returns indices of confluence cells, i.e. cells with two or more upstream neighbors"""
     nup = upstream_count(idxs_ds, mask=mask, mv=mv)
     return np.where(nup > 1)[0].astype(idxs_ds.dtype)
 
 
-@njit
+@njit(cache=True)
 def flwdir_tuples(idxs_ds, mask=None, mv=_mv):
     """Returns list of up- and downstream linear index couples."""
     idxs = []
@@ -272,7 +272,7 @@ def flwdir_tuples(idxs_ds, mask=None, mv=_mv):
 # local functions
 
 
-@njit
+@njit(cache=True)
 def _d8_idx(idx0, shape):
     """Returns linear indices of eight neighboring cells"""
     nrow, ncol = shape
@@ -291,7 +291,7 @@ def _d8_idx(idx0, shape):
     return np.array(idxs_lst)
 
 
-@njit
+@njit(cache=True)
 def _upstream_d8_idx(idx0, idxs_ds, shape):
     """Returns a numpy array with linear indices of upstream neighbors.
     NOTE: This method only works for D8 type of flow direciton data. If upstream
@@ -305,7 +305,7 @@ def _upstream_d8_idx(idx0, idxs_ds, shape):
 
 
 # TODO use pre-set distance or length raster
-@njit
+@njit(cache=True)
 def _trace(
     idx0,
     idxs_nxt,
@@ -366,7 +366,7 @@ def _trace(
     return np.array(idxs, dtype=idxs_nxt.dtype), dist
 
 
-@njit
+@njit(cache=True)
 def _window(idx0, n, idxs_ds, idxs_us_main, strord=None, mv=_mv):
     """Returns the indices of between the nth upstream to nth downstream cell from
     the current cell. Upstream cells are with based on the  _main_upstream method.
@@ -397,7 +397,7 @@ def _window(idx0, n, idxs_ds, idxs_us_main, strord=None, mv=_mv):
     return idxs
 
 
-@njit
+@njit(cache=True)
 def path(
     idxs0,
     idxs_nxt,
@@ -437,7 +437,7 @@ def path(
     return paths, dists
 
 
-@njit
+@njit(cache=True)
 def snap(
     idxs0,
     idxs_nxt,
@@ -481,7 +481,7 @@ def snap(
 
 
 # NOTE: not unit tested
-@njit
+@njit(cache=True)
 def inflow_idxs(idxs_ds, seq, region):
     """returns linear indices of most upstream cells within region"""
     idxs = []
@@ -498,7 +498,7 @@ def inflow_idxs(idxs_ds, seq, region):
 
 
 # NOTE: not unit tested
-@njit
+@njit(cache=True)
 def outflow_idxs(idxs_ds, seq, region):
     """returns linear indices of most downstream cells within region"""
     idxs = []

--- a/pyflwdir/core_d8.py
+++ b/pyflwdir/core_d8.py
@@ -19,7 +19,7 @@ _pv = np.array([0, 255], dtype=np.uint8)
 _all = np.array([32, 64, 128, 16, 0, 1, 8, 4, 2, 247, 255], dtype=np.uint8)
 
 
-@njit("Tuple((int8, int8))(uint8)")
+@njit("Tuple((int8, int8))(uint8)", cache=True)
 def drdc(dd):
     """convert d8 value to delta row/col"""
     dr, dc = np.int8(0), np.int8(0)
@@ -39,7 +39,7 @@ def drdc(dd):
     return dr, dc
 
 
-@njit
+@njit(cache=True)
 def from_array(flwdir, _mv=_mv, dtype=np.intp):
     """convert 2D D8 data to 1D next downstream indices"""
     nrow, ncol = flwdir.shape
@@ -67,7 +67,7 @@ def from_array(flwdir, _mv=_mv, dtype=np.intp):
     return idxs_ds, np.array(pits_lst, dtype=dtype), n
 
 
-@njit
+@njit(cache=True)
 def _downstream_idx(idx0, flwdir_flat, shape, mv=core._mv):
     """Returns linear index of the donwstream neighbor; idx0 if at pit"""
     nrow, ncol = shape
@@ -83,7 +83,7 @@ def _downstream_idx(idx0, flwdir_flat, shape, mv=core._mv):
 
 
 # general
-@njit
+@njit(cache=True)
 def to_array(idxs_ds: np.ndarray[np.uint64], shape: Tuple[int, int], mv=core._mv):
     """convert downstream linear indices to dense D8 raster"""
     ncol = shape[1]
@@ -112,7 +112,7 @@ def isvalid(flwdir: np.uint8, _all: np.ndarray[np.uint8] = _all) -> bool:
     )
 
 
-@njit
+@njit(cache=True)
 def check_values(flwdir, _all):
     check = True
     for dd in flwdir.ravel():
@@ -122,19 +122,19 @@ def check_values(flwdir, _all):
     return check
 
 
-@njit
+@njit(cache=True)
 def ispit(dd, _pv=_pv):
     """True if D8 pit"""
     return np.any(dd == _pv)
 
 
-@njit
+@njit(cache=True)
 def isnodata(dd, _mv=_mv):
     """True if D8 nodata"""
     return dd == _mv
 
 
-@njit
+@njit(cache=True)
 def _upstream_idx(idx0, flwdir_flat, shape, _us=_us, dtype=np.intp):
     """Returns a numpy array (int64) with linear indices of upstream neighbors"""
     nrow, ncol = shape

--- a/pyflwdir/core_ldd.py
+++ b/pyflwdir/core_ldd.py
@@ -21,7 +21,7 @@ from numba import njit
 import numpy as np
 
 
-@njit("Tuple((int8, int8))(uint8)")
+@njit("Tuple((int8, int8))(uint8)", cache=True)
 def drdc(dd):
     """convert ldd value to delta row/col"""
     dr, dc = np.int8(0), np.int8(0)
@@ -38,7 +38,7 @@ def drdc(dd):
     return dr, dc
 
 
-@njit
+@njit(cache=True)
 def from_array(flwdir, _mv=_mv, dtype=np.intp):
     """convert 2D LDD data to 1D next downstream indices"""
     nrow, ncol = flwdir.shape
@@ -66,7 +66,7 @@ def from_array(flwdir, _mv=_mv, dtype=np.intp):
     return idxs_ds, np.array(pits_lst, dtype=dtype), n
 
 
-@njit
+@njit(cache=True)
 def _downstream_idx(idx0, flwdir_flat, shape, mv=core._mv):
     """Returns linear index of the donwstream neighbor; idx0 if at pit"""
     nrow, ncol = shape
@@ -82,7 +82,7 @@ def _downstream_idx(idx0, flwdir_flat, shape, mv=core._mv):
 
 
 # general
-@njit
+@njit(cache=True)
 def to_array(idxs_ds, shape, mv=core._mv):
     """convert downstream linear indices to dense D8 raster"""
     ncol = shape[1]
@@ -106,19 +106,19 @@ def isvalid(flwdir, _all=_all):
     return core_d8.isvalid(flwdir, _all)
 
 
-@njit
+@njit(cache=True)
 def ispit(dd, _pv=_pv):
     """True if LDD pit"""
     return dd == _pv
 
 
-@njit
+@njit(cache=True)
 def isnodata(dd, _mv=_mv):
     """True if LDD nodata"""
     return core_d8.isnodata(dd, _mv)
 
 
-@njit
+@njit(cache=True)
 def _upstream_idx(idx0, flwdir_flat, shape, _us=_us, dtype=np.intp):
     """Returns a numpy array (int64) with linear indices of upstream neighbors"""
     return core_d8._upstream_idx(idx0, flwdir_flat, shape, _us, dtype=dtype)

--- a/pyflwdir/core_nextxy.py
+++ b/pyflwdir/core_nextxy.py
@@ -38,7 +38,7 @@ def to_array(idxs_ds, shape, mv=core._mv):
     return np.stack([nextx, nexty])
 
 
-@njit
+@njit(cache=True)
 def _from_array(nextx, nexty, _mv=_mv, dtype=np.intp):
     size = nextx.size
     nrow, ncol = nextx.shape[0], nextx.shape[-1]
@@ -68,7 +68,7 @@ def _from_array(nextx, nexty, _mv=_mv, dtype=np.intp):
     return idxs_ds, np.array(pits_lst, dtype=dtype), n
 
 
-@njit
+@njit(cache=True)
 def _to_array(idxs_ds, shape, mv=core._mv):
     """convert 1D index to 3D NEXTXY raster"""
     ncol = shape[1]
@@ -107,13 +107,13 @@ def isvalid(flwdir):
     )
 
 
-@njit
+@njit(cache=True)
 def ispit(dd, _pv=_pv):
     """True if NEXTXY pit"""
     return np.logical_or(dd == _pv[0], dd == _pv[1])
 
 
-@njit
+@njit(cache=True)
 def isnodata(dd):
     """True if NEXTXY nodata"""
     return dd == _mv

--- a/pyflwdir/dem.py
+++ b/pyflwdir/dem.py
@@ -14,7 +14,7 @@ _mv = core._mv
 __all__ = ["slope", "fill_depressions"]
 
 
-@njit
+@njit(cache=True)
 def fill_depressions(
     elevtn,
     outlets="edge",
@@ -143,7 +143,7 @@ def fill_depressions(
     return elevtn + delv, d8
 
 
-@njit
+@njit(cache=True)
 def adjust_elevation(idxs_ds, seq, elevtn, mv=_mv):
     """Given a flow direction map, remove pits in the elevation map.
     Algorithm based on Yamazaki et al. (2012)
@@ -167,7 +167,7 @@ def adjust_elevation(idxs_ds, seq, elevtn, mv=_mv):
     return elevtn_out
 
 
-@njit
+@njit(cache=True)
 def _adjust_elevation(elevtn):
     """fix elevation on single streamline based on minimum modification
     elevtn oderdered from up- to downstream
@@ -225,7 +225,7 @@ def _adjust_elevation(elevtn):
     return elevtn
 
 
-@njit
+@njit(cache=True)
 def slope(elevtn, nodata=-9999.0, latlon=False, transform=gis_utils.IDENTITY):
     """Returns the local gradient
 
@@ -379,7 +379,7 @@ def floodplains(idxs_ds, seq, elevtn, uparea, upa_min=1000.0, b=0.3):
     return fldpln
 
 
-@njit
+@njit(cache=True)
 def _local_d4(idx0, idx_ds, ncol):
     """Return indices of d4 neighbors in diagonal d8 direction, e.g.: indices of N, W neigbors if flowdir is NW."""
     idxs_d4 = [
@@ -402,7 +402,7 @@ def _local_d4(idx0, idx_ds, ncol):
         return np.asarray(idxs_d4[1:])
 
 
-@njit
+@njit(cache=True)
 def dig_4connectivity(
     idxs_ds, seq, elv_flat, shape, mask=None, nodata=-9999, dz_min=1e-3
 ):

--- a/pyflwdir/gis_utils.py
+++ b/pyflwdir/gis_utils.py
@@ -28,7 +28,7 @@ __all__ = [
 ]
 
 
-@njit()
+@njit(cache=True)
 def spread2d(obs, msk=None, nodata=0, frc=None, latlon=False, transform=IDENTITY):
     """Returns filled array with nearest observations, origin cells and friction distance to origin.
     The friction distance is measured through valid cells in the mask and has a uniform value of 1. by default.
@@ -114,7 +114,7 @@ def spread2d(obs, msk=None, nodata=0, frc=None, latlon=False, transform=IDENTITY
     return out, src, dst
 
 
-@njit
+@njit(cache=True)
 def get_edge(a, structure=np.ones((3, 3), dtype=bool)):
     """Get edge of valid cells.
 
@@ -402,7 +402,7 @@ def area_grid(transform, shape, latlon=False, unit="m2"):
     return area
 
 
-@njit
+@njit(cache=True)
 def cellarea(lat, xres, yres):
     """returns the area of cell with a given resolution (resx,resy) at a given
     cell center latitude [m2]."""
@@ -412,7 +412,7 @@ def cellarea(lat, xres, yres):
     return _R**2 * dx * (np.sin(l2) - np.sin(l1))
 
 
-@njit
+@njit(cache=True)
 def degree_metres_y(lat):
     """ "returns the verical length of a degree in metres at
     a given latitude."""
@@ -431,7 +431,7 @@ def degree_metres_y(lat):
     return latlen
 
 
-@njit
+@njit(cache=True)
 def degree_metres_x(lat):
     """ "returns the horizontal length of a degree in metres at
     a given latitude."""
@@ -448,7 +448,7 @@ def degree_metres_x(lat):
     return longlen
 
 
-@njit
+@njit(cache=True)
 def distance(idx0, idx1, ncol, latlon=False, transform=IDENTITY):
     """Return the the length between linear indices idx0 and idx1 on a regular raster
     defined by the affine transform.

--- a/pyflwdir/regions.py
+++ b/pyflwdir/regions.py
@@ -125,7 +125,7 @@ def region_bounds(regions, transform=gis_utils.IDENTITY):
     return lbs, bboxs, total_bbox
 
 
-@njit
+@njit(cache=True)
 def region_outlets(regions, idxs_ds, seq):
     """Returns the linear index of the outlet cell in `regions`.
 

--- a/pyflwdir/rivers.py
+++ b/pyflwdir/rivers.py
@@ -7,7 +7,7 @@ import logging
 logger = logging.Logger(__name__)
 
 
-@njit
+@njit(cache=True)
 def classify_estuary(
     idxs_ds: np.ndarray,
     seq: np.ndarray,

--- a/pyflwdir/streams.py
+++ b/pyflwdir/streams.py
@@ -12,7 +12,7 @@ __all__ = []
 
 
 # general methods
-@njit
+@njit(cache=True)
 def accuflux(idxs_ds, seq, data, nodata):
     """Returns maps of accumulate upstream <data>
 
@@ -41,7 +41,7 @@ def accuflux(idxs_ds, seq, data, nodata):
     return accu
 
 
-@njit
+@njit(cache=True)
 def accuflux_ds(idxs_ds, seq, data, nodata):
     """Returns maps of accumulate downstream <data>
 
@@ -70,7 +70,7 @@ def accuflux_ds(idxs_ds, seq, data, nodata):
     return accu
 
 
-@njit()
+@njit(cache=True)
 def upstream_area(
     idxs_ds,
     seq,
@@ -129,7 +129,7 @@ def upstream_area(
     return uparea
 
 
-@njit
+@njit(cache=True)
 def streams(idxs_ds, seq, mask=None, max_len=0, mv=core._mv):
     """Returns list of linear indices per stream of equal stream order.
 
@@ -188,7 +188,7 @@ def streams(idxs_ds, seq, mask=None, max_len=0, mv=core._mv):
     return streams
 
 
-@njit
+@njit(cache=True)
 def stream_order(idxs_ds, seq, idxs_us_main, mask=None, mv=core._mv):
     """Returns the classic or Hack's "bottum up" stream order.
 
@@ -225,7 +225,7 @@ def stream_order(idxs_ds, seq, idxs_us_main, mask=None, mv=core._mv):
     return strord
 
 
-@njit
+@njit(cache=True)
 def strahler_order(idxs_ds, seq, mask=None):
     """Returns the strahler "top down" stream order.
 
@@ -315,7 +315,7 @@ def stream_distance(
     return dist
 
 
-@njit
+@njit(cache=True)
 def smooth_rivlen(
     idxs_ds,
     idxs_us_main,

--- a/pyflwdir/subgrid.py
+++ b/pyflwdir/subgrid.py
@@ -48,7 +48,7 @@ def outlets(idxs_ds, uparea, cellsize, shape, method="eam_plus", mv=_mv):
     return idxs_out, shape_out
 
 
-@njit
+@njit(cache=True)
 def ucat_area(
     idxs_out,
     idxs_ds,
@@ -93,7 +93,7 @@ def ucat_area(
     return ucatch_map, ucatch_are
 
 
-@njit
+@njit(cache=True)
 def ucat_volume(
     idxs_out,
     idxs_ds,
@@ -142,7 +142,7 @@ def ucat_volume(
     return ucatch_map, fldpln_vol
 
 
-@njit
+@njit(cache=True)
 def segment_length(
     idxs_out,
     idxs_nxt,
@@ -205,7 +205,7 @@ def segment_length(
     return rivlen
 
 
-@njit
+@njit(cache=True)
 def segment_average(
     idxs_out,
     idxs_nxt,
@@ -273,7 +273,7 @@ def segment_average(
 
 
 ## NOTE: not unit tested
-@njit
+@njit(cache=True)
 def segment_median(
     idxs_out,
     idxs_nxt,
@@ -338,7 +338,7 @@ def segment_median(
 
 
 ## NOTE: not unit tested
-@njit
+@njit(cache=True)
 def segment_indices(
     idxs_out,
     idxs_nxt,
@@ -411,7 +411,7 @@ def segment_indices(
 
 
 ## NOTE: not unit tested
-@njit
+@njit(cache=True)
 def segment_slope(
     idxs_out,
     idxs_nxt,
@@ -485,7 +485,7 @@ def segment_slope(
     return rivslp
 
 
-@njit
+@njit(cache=True)
 def fixed_length_slope(
     idxs_out,
     idxs_ds,

--- a/pyflwdir/upscale.py
+++ b/pyflwdir/upscale.py
@@ -19,7 +19,7 @@ __all__ = []
 
 
 #### GENERIC CONVENIENCE FUNCTIONS ####
-@njit
+@njit(cache=True)
 def subidx_2_idx(subidx, subncol, cellsize, ncol):
     """Returns the lowres index <idx> of highres cell index <subidx>."""
     r = int(subidx // subncol) // cellsize
@@ -27,7 +27,7 @@ def subidx_2_idx(subidx, subncol, cellsize, ncol):
     return r * ncol + c
 
 
-@njit
+@njit(cache=True)
 def in_d8(idx0, idx_ds, ncol):
     """Returns True if inside 3x3 (current and 8 neighboring) cells."""
     cond1 = abs(int(idx_ds % ncol) - int(idx0 % ncol)) <= 1  # west - east
@@ -38,7 +38,7 @@ def in_d8(idx0, idx_ds, ncol):
 #### DOUBLE MAXIMUM METHOD ####
 
 
-@njit
+@njit(cache=True)
 def cell_edge(subidx, subncol, cellsize):
     """Returns True if highres cell <subidx> is on edge of lowres cell"""
     ri = (subidx // subncol) % cellsize
@@ -46,7 +46,7 @@ def cell_edge(subidx, subncol, cellsize):
     return ri == 0 or ci == 0 or ri + 1 == cellsize or ci + 1 == cellsize
 
 
-@njit
+@njit(cache=True)
 def map_celledge(subidxs_ds, subshape, cellsize, mv=_mv):
     """Returns a map with ones on highres cells of lowres cell edges"""
     subncol = subshape[1]
@@ -63,7 +63,7 @@ def map_celledge(subidxs_ds, subshape, cellsize, mv=_mv):
     return edges
 
 
-@njit
+@njit(cache=True)
 def dmm_exitcell(subidxs_ds, subuparea, subshape, shape, cellsize, mv=_mv):
     """Returns exit highres cell indices of lowres cells according to the
     double maximum method (DMM).
@@ -111,7 +111,7 @@ def dmm_exitcell(subidxs_ds, subuparea, subshape, shape, cellsize, mv=_mv):
     return subidxs_rep
 
 
-@njit
+@njit(cache=True)
 def dmm_nextidx(subidxs_rep, subidxs_ds, subshape, shape, cellsize, mv=_mv):
     """Returns next downstream lowres index by tracing a representative cell
     to where it leaves a buffered area around the lowres cell according to the
@@ -211,7 +211,7 @@ def dmm(subidxs_ds, subuparea, subshape, cellsize, mv=_mv):
 #### EFFECTIVE AREA METHOD ####
 
 
-@njit
+@njit(cache=True)
 def effective_area(subidx, subncol, cellsize, r_ratio=0.5):
     """Returns True if highress cell <subidx> is inside the effective area."""
     R = cellsize * r_ratio
@@ -223,7 +223,7 @@ def effective_area(subidx, subncol, cellsize, r_ratio=0.5):
     return ea
 
 
-@njit
+@njit(cache=True)
 def map_effare(subidxs_ds, subshape, cellsize, r_ratio=0.5, mv=_mv):
     """Returns a map with ones on highres cells of lowres effective area."""
     subncol = subshape[1]
@@ -240,7 +240,7 @@ def map_effare(subidxs_ds, subshape, cellsize, r_ratio=0.5, mv=_mv):
     return effare
 
 
-@njit
+@njit(cache=True)
 def eam_repcell(subidxs_ds, subuparea, subshape, shape, cellsize, r_ratio=0.5, mv=_mv):
     """Returns representative highres cell indices of lowres cells
     according to the effective area method.
@@ -287,7 +287,7 @@ def eam_repcell(subidxs_ds, subuparea, subshape, shape, cellsize, r_ratio=0.5, m
     return subidxs_rep
 
 
-@njit
+@njit(cache=True)
 def eam_nextidx(
     subidxs_rep, subidxs_ds, subshape, shape, cellsize, r_ratio=0.5, mv=_mv
 ):
@@ -377,7 +377,7 @@ def eam(subidxs_ds, subuparea, subshape, cellsize, r_ratio=0.5, mv=_mv):
 
 
 #### CONNECTING OUTLETS SCALING METHOD ####
-@njit
+@njit(cache=True)
 def ihu_outlets(
     subidxs_rep,
     subidxs_ds,
@@ -434,7 +434,7 @@ def ihu_outlets(
     return subidxs_out
 
 
-@njit
+@njit(cache=True)
 def ihu_nextidx(
     subidxs_out, subidxs_ds, subshape, shape, cellsize, r_ratio=0.5, mv=_mv
 ):
@@ -496,7 +496,7 @@ def ihu_nextidx(
     return idxs_ds, np.array(idxs_fix, dtype=subidxs_ds.dtype)
 
 
-@njit
+@njit(cache=True)
 def next_outlet(
     subidx,
     subidxs_ds,
@@ -519,7 +519,7 @@ def next_outlet(
     return subidx1, idx1, outlet
 
 
-@njit
+@njit(cache=True)
 def ihu_relocate_outlets(
     idxs_fix,
     idxs_ds,
@@ -877,7 +877,7 @@ def ihu_relocate_outlets(
     return idxs_ds, subidxs_out, np.array(idxs_fix_out, dtype=idxs_ds.dtype)
 
 
-@njit
+@njit(cache=True)
 def outlet_pix(idx, subidxs_ds, ncol, subncol, cellsize, all=False):
     """Returns subgrid cells at the edge of a lowres cells with the next downstream
     subgrid cell outside of that lowres cell."""
@@ -905,7 +905,7 @@ def outlet_pix(idx, subidxs_ds, ncol, subncol, cellsize, all=False):
     return subidxs
 
 
-@njit
+@njit(cache=True)
 def new_outlet(
     idx0,
     subidx0,
@@ -968,7 +968,7 @@ def new_outlet(
     return streams, idxs_ds, subidxs_out, idx_ds != mv
 
 
-@njit
+@njit(cache=True)
 def ihu_optimize_rivlen(
     idxs_short,
     valid,
@@ -1019,7 +1019,7 @@ def ihu_optimize_rivlen(
     return idxs_ds, subidxs_out
 
 
-@njit
+@njit(cache=True)
 def ihu_minimize_error(
     idxs_fix,
     valid,
@@ -1309,7 +1309,7 @@ def eam_plus(subidxs_ds, subuparea, subshape, cellsize, mv=_mv):
     return ihu(subidxs_ds, subuparea, subshape, cellsize, niter=0, mv=mv)
 
 
-@njit
+@njit(cache=True)
 def upscale_error(subidxs_out, idxs_ds, subidxs_ds, mv=_mv):
     """Returns an array with ones (zeros) if subgrid outlet/representative cells are
     valid (erroneous) in D8, cells with missing values are set to -1.
@@ -1363,7 +1363,7 @@ def upscale_error(subidxs_out, idxs_ds, subidxs_ds, mv=_mv):
     return connect_map, np.array(idxs_fix_lst, dtype=idxs_ds.dtype)
 
 
-@njit
+@njit(cache=True)
 def upscale_check(subidxs_out, idxs_ds, subidxs_ds, minlen=0, mv=_mv):
     # array with outlets (>=0) and streams (-1); nodata value is -9
     assert subidxs_out.size <= 2147483648


### PR DESCRIPTION
## Issue addressed
Fixes #78 

## Explanation
Without caching, numba needs to re-compile every time Python is re-run. With caching pyflwdir is much faster the second time.

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed
- [x] Updated CHANGELOG.rst if needed

## Additional Notes (optional)
Tests were run
