### PR TITLE
Fix moving window bool negation warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Change Log
 
 in development
 **************
+* fix bool negation in moving window stream-order restriction (#88)
 
 0.5.11 (21-04-2026)
 ********************

--- a/pyflwdir/flwdir.py
+++ b/pyflwdir/flwdir.py
@@ -460,7 +460,7 @@ class Flwdir(object):
             n=n,
             idxs_ds=self.idxs_ds,
             idxs_us_main=self.idxs_us_main,
-            strord=self._check_data(strord, "strord", optional=~restrict_strord),
+            strord=self._check_data(strord, "strord", optional=not restrict_strord),
             nodata=nodata,
             mv=self._mv,
         )
@@ -494,7 +494,7 @@ class Flwdir(object):
             n=n,
             idxs_ds=self.idxs_ds,
             idxs_us_main=self.idxs_us_main,
-            strord=self._check_data(strord, "strord", optional=~restrict_strord),
+            strord=self._check_data(strord, "strord", optional=not restrict_strord),
             nodata=nodata,
             mv=self._mv,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ exclude = ["docs", "notebooks", "envs", "tests", "binder", ".github"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+filterwarnings = ["error"]
 
 [tool.make_env]
 channels = ["conda-forge"]

--- a/tests/test_pyflwdir.py
+++ b/tests/test_pyflwdir.py
@@ -168,6 +168,15 @@ def test_moving_average(flw0, flwdir0_rank):
     data = np.random.random(flw0.shape)
     data_smooth = flw0.moving_average(data, n=1, weights=np.ones(flw0.shape))
     assert np.all(data_smooth == flw0.moving_average(data, n=1))
+    strord = flw0.stream_order()
+    assert np.allclose(
+        flw0.moving_average(data, n=1, restrict_strord=True),
+        flw0.moving_average(data, n=1, restrict_strord=True, strord=strord),
+    )
+    assert np.allclose(
+        flw0.moving_median(data, n=1, restrict_strord=True),
+        flw0.moving_median(data, n=1, restrict_strord=True, strord=strord),
+    )
     idxs = flw0.path(idxs_seq[-1], max_length=2)[0][0]
     assert np.isclose(np.mean(data.flat[idxs]), data_smooth.flat[idxs[1]])
     with pytest.raises(ValueError, match="size does not match"):


### PR DESCRIPTION
## Issue addressed
Fixes #88

## Explanation
`moving_average()` and `moving_median()` used `~restrict_strord` when deciding whether `strord` is optional. On bools this emits a Python 3.12+ `DeprecationWarning`, and it also leaves `strord` optional even when `restrict_strord=True`.

This replaces the bitwise inversion with boolean negation, adds a regression check for automatic `strord` calculation under `restrict_strord=True`, and configures pytest warnings as errors.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [ ] Updated documentation if needed
- [x] Updated CHANGELOG.rst if needed

## Additional Notes
Not run locally.

Remote GitHub workflows are currently waiting for maintainer approval for this fork PR and have no logs or check results yet:

- `Tests Coverage`: https://github.com/Deltares/pyflwdir/actions/runs/26182562303
- `Linting`: https://github.com/Deltares/pyflwdir/actions/runs/26182562301
- `Tests`: https://github.com/Deltares/pyflwdir/actions/runs/26182562302
- `Build Documentation`: https://github.com/Deltares/pyflwdir/actions/runs/26182562305