### PR TITLE
Use signed int64 index dtype for very large rasters (fixes #79)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Change Log
 in development
 **************
 * fix bool negation in moving window stream-order restriction (#88)
+* use a signed ``int64`` (instead of ``uint64``) index dtype for very large rasters so upscaling no longer fails with a numba typing error (#79)
 
 0.5.11 (21-04-2026)
 ********************

--- a/pyflwdir/pyflwdir.py
+++ b/pyflwdir/pyflwdir.py
@@ -102,6 +102,31 @@ def from_dem(
     )
 
 
+def _get_idxs_dtype(n):
+    """Return the smallest integer dtype that can represent ``n`` indices.
+
+    A signed ``int64`` (rather than ``uint64``) is used for the largest
+    rasters: mixing unsigned 64-bit indices with the signed missing value
+    (``core._mv``) or signed integers promotes them to ``float64`` in numba,
+    which then fails to index the arrays (see #79). ``int64`` still covers up
+    to ``2**63 - 1`` cells, far beyond any realistic raster size.
+
+    Parameters
+    ----------
+    n : int
+        Number of indices (i.e. raster cells) to represent.
+
+    Returns
+    -------
+    dtype : numpy data type
+    """
+    if n < 2147483647:  # 2**31 - 1
+        return np.int32
+    elif n < 4294967294:  # 2**32 - 2
+        return np.uint32
+    return np.int64
+
+
 def from_array(
     data,
     ftype="infer",
@@ -163,8 +188,7 @@ def from_array(
         data = np.where(mask != 0, data, fd._mv)
 
     # use smallest possible dtype to represent indices
-    n = data.size
-    dtype = np.int32 if n < 2147483647 else (np.uint32 if n < 4294967294 else np.uint64)
+    dtype = _get_idxs_dtype(data.size)
     idxs_ds, idxs_pit, _ = fd.from_array(data, dtype=dtype)
     idxs_outlet = idxs_pit[np.isin(data.flat[idxs_pit], fd._pv)]
 

--- a/pyflwdir/pyflwdir.py
+++ b/pyflwdir/pyflwdir.py
@@ -188,7 +188,7 @@ def from_array(
         data = np.where(mask != 0, data, fd._mv)
 
     # use smallest possible dtype to represent indices
-    dtype = _get_idxs_dtype(data.size)
+    dtype = _get_idxs_dtype(shape[0] * shape[1])
     idxs_ds, idxs_pit, _ = fd.from_array(data, dtype=dtype)
     idxs_outlet = idxs_pit[np.isin(data.flat[idxs_pit], fd._pv)]
 

--- a/tests/test_pyflwdir.py
+++ b/tests/test_pyflwdir.py
@@ -8,7 +8,7 @@ from affine import Affine
 
 import pyflwdir
 from pyflwdir import core
-from pyflwdir.pyflwdir import FlwdirRaster
+from pyflwdir.pyflwdir import FlwdirRaster, _get_idxs_dtype
 
 
 @pytest.mark.parametrize("flwdir, ftype", [("flwdir0", "d8"), ("nextxy0", "nextxy")])
@@ -33,6 +33,18 @@ def test_from_array_errors(flw0, flwdir0):
         pyflwdir.from_array(flwdir0, ftype="ldd", check_ftype=True)
     with pytest.raises(ValueError, match="shape does not match"):
         pyflwdir.from_array(flwdir0, mask=np.ones((1, 1)))
+
+
+def test_get_idxs_dtype():
+    # the smallest possible dtype is used to represent the indices
+    assert _get_idxs_dtype(100) == np.int32
+    assert _get_idxs_dtype(2147483647) == np.uint32
+    # rasters with more than ~4.29e9 cells must use a signed dtype: a uint64
+    # index dtype is promoted to float64 in numba and breaks indexing (#79)
+    for n in (4294967294, 10_000_000_000):
+        dtype = _get_idxs_dtype(n)
+        assert np.issubdtype(dtype, np.signedinteger)
+        assert np.iinfo(dtype).max >= n
 
 
 def test_flwdirraster_errors(flwdir0, flwdir0_idxs):

--- a/tests/test_pyflwdir.py
+++ b/tests/test_pyflwdir.py
@@ -2,6 +2,8 @@
 """Tests for the pyflwdir module, specifically the wrapping of the methods which
 themselves are testes elsewhere"""
 
+import importlib
+
 import numpy as np
 import pytest
 from affine import Affine
@@ -9,6 +11,8 @@ from affine import Affine
 import pyflwdir
 from pyflwdir import core
 from pyflwdir.pyflwdir import FlwdirRaster, _get_idxs_dtype
+
+pyflwdir_module = importlib.import_module("pyflwdir.pyflwdir")
 
 
 @pytest.mark.parametrize("flwdir, ftype", [("flwdir0", "d8"), ("nextxy0", "nextxy")])
@@ -45,6 +49,20 @@ def test_get_idxs_dtype():
         dtype = _get_idxs_dtype(n)
         assert np.issubdtype(dtype, np.signedinteger)
         assert np.iinfo(dtype).max >= n
+
+
+def test_from_array_nextxy_gets_dtype_from_cell_count(monkeypatch, nextxy0):
+    calls = []
+
+    def get_idxs_dtype(n):
+        calls.append(n)
+        return np.int32
+
+    monkeypatch.setattr(pyflwdir_module, "_get_idxs_dtype", get_idxs_dtype)
+
+    pyflwdir.from_array(nextxy0, ftype="nextxy")
+
+    assert calls == [nextxy0.shape[1] * nextxy0.shape[2]]
 
 
 def test_flwdirraster_errors(flwdir0, flwdir0_idxs):


### PR DESCRIPTION
## Summary

Fixes #79.

Upscaling a flow-direction raster with more than ~4.29e9 cells (e.g. HydroSHEDS 3 arc-second Africa, 96000×96000) fails with a numba `TypingError`:

```
No implementation of function Function(<built-in function getitem>) found for signature:
 >>> getitem(array(uint64, 1d, C), float64)
```

## Cause

`from_array` picks the index dtype from the cell count:

```python
dtype = np.int32 if n < 2147483647 else (np.uint32 if n < 4294967294 else np.uint64)
```

so rasters with > ~4.29e9 cells get **uint64** indices. Inside the numba routines (e.g. `upscale.ihu_relocate_outlets`) these unsigned 64-bit indices are combined with the **signed** missing value `core._mv` (`np.intp(-1)`) and signed integer literals. numpy/numba have no common integer type for `uint64` + `int64`, so the result is promoted to **float64** — and a float can no longer index the (uint64) arrays, hence the typing error.

Smaller rasters use `int32`/`uint32`, both of which promote to `int64` when mixed with the signed missing value, so they are unaffected — which is why this only shows up for the very largest rasters.

## Fix

Use a signed **int64** index dtype (instead of `uint64`) for the largest rasters. `int64` covers up to `2**63 - 1` cells — far beyond any realistic raster, so this does **not** limit the supported raster size — and it matches the signed missing value, so no float promotion occurs. The `int32`/`uint32` cases are unchanged.

The dtype selection is factored into a small `_get_idxs_dtype` helper so it can be unit-tested.

## Verification

Reproduced and verified directly (numba JIT **enabled**) on the bundled `tests/data/flwdir.asc`, forcing each index dtype via `core_d8.from_array(..., dtype=...)`:

| index dtype | `flw.upscale(method="ihu")` |
|-------------|------------------------------|
| `int32`   | ✅ ok |
| `uint32`  | ✅ ok |
| **`uint64`** | ❌ numba `TypingError` (the reported bug) |
| **`int64`** (the fix) | ✅ ok |

`int32` and `int64` produce identical `idxs_out`, so the fix changes only the dtype, not the result.

- New unit test `test_get_idxs_dtype` asserts a **signed** dtype that can hold the cell count is selected for large rasters (fails on the old `uint64` selection).
- Full test suite passes (83 passed).
- `black` reports both changed files unchanged.

Note: the test suite runs with `NUMBA_DISABLE_JIT=1` (set in `conftest.py`), so the numba typing error itself only surfaces with JIT enabled; the added unit test therefore guards the dtype-selection invariant rather than recompiling under JIT.