### PR TITLE
Store the upstream cells in CSR layout in core.idxs_seq

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ unreleased
 *******************
 * add FlwdirRaster.subbasins method to create subbasins at all river confluences
 * implement type checking with mypy (overdue maintenance)
+* build the upstream cell index in CSR layout in ``core.idxs_seq``, reducing
+  the memory and runtime of ``order_cells(method="walk")`` (#114)
 
 0.5.12 (01-07-2026)
 *******************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,12 @@ unreleased
 * build the upstream cell index in CSR layout in ``core.idxs_seq``, reducing
   the memory and runtime of ``order_cells(method="walk")`` (#114)
 * make ``method="walk"`` the default of ``order_cells`` and ``idxs_seq`` for
-  ``Flwdir`` and ``FlwdirRaster``, including the ``nextxy`` type (#115)
+  ``Flwdir`` and ``FlwdirRaster``, including the ``nextxy`` type. Both orderings
+  run from down- to upstream; the order among cells of equal rank differs, so
+  floating point accumulations over ``Flwdir`` networks and ``nextxy`` rasters
+  can differ in the last bits from earlier versions (#115)
+* treat a ``nextxy`` cell whose next cell is itself as a pit in
+  ``core_nextxy.from_array``; it was left out of the pit list (#115)
 
 0.5.12 (01-07-2026)
 *******************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ unreleased
 * implement type checking with mypy (overdue maintenance)
 * build the upstream cell index in CSR layout in ``core.idxs_seq``, reducing
   the memory and runtime of ``order_cells(method="walk")`` (#114)
+* make ``method="walk"`` the default of ``order_cells`` and ``idxs_seq`` for
+  ``Flwdir`` and ``FlwdirRaster``, including the ``nextxy`` type (#115)
 
 0.5.12 (01-07-2026)
 *******************

--- a/pyflwdir/core.py
+++ b/pyflwdir/core.py
@@ -89,6 +89,62 @@ def upstream_matrix(idxs_ds: np.ndarray, mv: int = _mv) -> np.ndarray:
 
 
 @njit(cache=True)
+def upstream_csr(idxs_ds: np.ndarray, mv: int = _mv) -> tuple[np.ndarray, np.ndarray]:
+    """Returns the upstream cell indices in compressed sparse row (CSR) layout.
+
+    The upstream cells of cell `i` are `idxs_us[indptr[i]:indptr[i+1]]`, sorted
+    by linear index. This holds one entry per upstream cell, where
+    `upstream_matrix` reserves as many entries for every cell as the largest
+    number of upstream cells found anywhere in the data.
+
+    Parameters
+    ----------
+    idxs_ds : 1D-array of int
+        linear index of next downstream cell
+    mv : int
+        missing value
+
+    Returns
+    -------
+    indptr : 1D-array of int
+        start of the upstream cells of each cell in idxs_us; size n + 1
+    idxs_us : 1D-array of int
+        linear indices of upstream cells, grouped per downstream cell; size e
+
+    See Also
+    --------
+    upstream_matrix
+
+    Notes
+    -----
+    With n cells and e upstream cells this takes O(n + e) time and n + 1 + e
+    values of memory, against n * d values for `upstream_matrix`, where d is the
+    largest number of upstream cells of any cell. Note that e < n because every
+    cell drains to at most one other cell, while d is set by the single most
+    branched cell in the data.
+    """
+    n = idxs_ds.size
+    # count the upstream cells of each cell; a pit is not upstream of itself
+    indptr = np.zeros(n + 1, dtype=idxs_ds.dtype)
+    for idx0 in range(n):
+        idx_ds = idxs_ds[idx0]
+        if idx_ds != idx0 and idx_ds != mv:
+            indptr[idx_ds] += 1
+    # cumulative sum; indptr[i] is now the END of the slice of cell i
+    for i in range(1, n + 1):
+        indptr[i] += indptr[i - 1]
+    # fill the slices back to front, which sorts each slice by linear index and
+    # leaves indptr[i] at the START of the slice of cell i
+    idxs_us = np.full(indptr[n], mv, dtype=idxs_ds.dtype)
+    for idx0 in range(n - 1, -1, -1):
+        idx_ds = idxs_ds[idx0]
+        if idx_ds != idx0 and idx_ds != mv:
+            indptr[idx_ds] -= 1
+            idxs_us[indptr[idx_ds]] = idx0
+    return indptr, idxs_us
+
+
+@njit(cache=True)
 def idxs_seq(idxs_ds: np.ndarray, idxs_pit: np.ndarray, mv: int = _mv) -> np.ndarray:
     """Returns indices ordered from down- to upstream.
 
@@ -101,21 +157,24 @@ def idxs_seq(idxs_ds: np.ndarray, idxs_pit: np.ndarray, mv: int = _mv) -> np.nda
     -------
     idxs_seq : ndarray of int, optional
         linear indices of valid cells ordered from down- to upstream
+
+    Notes
+    -----
+    Breadth-first traversal from the pits, upstream over the flow network. With
+    n cells and e upstream cells this takes O(n + e) time and memory, as every
+    cell is added to the sequence once and every upstream cell is read once.
     """
     i, j = 0, 0
-    idxs_us = upstream_matrix(idxs_ds, mv=mv)
+    indptr, idxs_us = upstream_csr(idxs_ds, mv=mv)
     idxs_seq = np.full(idxs_ds.size, mv, idxs_ds.dtype)
     for idx in idxs_pit:
         idxs_seq[j] = idx
         j += 1
-    while i < idxs_seq.size:
-        idx0 = idxs_seq[i]
-        if idx0 == mv:
-            break
-        for idx in idxs_us[idx0, :]:
-            if idx == mv:
-                break
-            idxs_seq[j] = idx
+    while i < j:  # i: cell being expanded, j: next free position
+        # a signed index; adding to an unsigned index promotes to float (#79)
+        idx0 = np.intp(idxs_seq[i])
+        for k in range(np.intp(indptr[idx0]), np.intp(indptr[idx0 + 1])):
+            idxs_seq[j] = idxs_us[k]
             j += 1
         i += 1
     return idxs_seq[:i]

--- a/pyflwdir/core_nextxy.py
+++ b/pyflwdir/core_nextxy.py
@@ -70,8 +70,8 @@ def _from_array(
         r_ds, c_ds = np.intp(r1 - 1), np.intp(c1 - 1)
         outside = r_ds >= nrow or c_ds >= ncol or r_ds < 0 or c_ds < 0
         idx_ds = c_ds + r_ds * ncol
-        # pit or outside or ds cell is mv
-        if pit or outside or nextx_flat[idx_ds] == _mv:
+        # pit or outside or ds cell is mv or points to itself
+        if pit or outside or idx_ds == idx0 or nextx_flat[idx_ds] == _mv:
             pits_lst.append(idx0)
             idxs_ds[idx0] = idx0
         else:

--- a/pyflwdir/flwdir.py
+++ b/pyflwdir/flwdir.py
@@ -237,7 +237,6 @@ class Flwdir:
             rnk, n = core.rank(self.idxs_ds, mv=self._mv)
             self._seq = np.argsort(rnk)[-n:].astype(self.idxs_ds.dtype)
         elif method == "walk":
-            # faster for large arrays, but also takes lots of memory
             self._seq = core.idxs_seq(self.idxs_ds, self.idxs_pit, self._mv)
         else:
             raise ValueError(f'Invalid method {method}, select from ["walk", "sort"]')

--- a/pyflwdir/flwdir.py
+++ b/pyflwdir/flwdir.py
@@ -229,7 +229,8 @@ class Flwdir:
         method: {'sort', 'walk'}, optional
             Method to order nodes, based on a "sorting" algorithm where nodes are
             sorted based on their rank (might be slow for large arrays) or "walking"
-            algorithm where nodes are traced from down- to upstream (uses more memory)
+            algorithm where nodes are traced from down- to upstream (faster, but
+            holds the upstream cells of the whole network in memory)
         """
         if method == "sort":
             # slow for large arrays

--- a/pyflwdir/flwdir.py
+++ b/pyflwdir/flwdir.py
@@ -248,7 +248,7 @@ class Flwdir:
             Method to order nodes: the default "walk" traces the nodes from down- to
             upstream, holding the upstream cells of the whole network in memory in
             compressed sparse row layout; "sort" sorts the nodes on their rank,
-            which is slower for large arrays.
+            which can be slower for large arrays.
         """
         if method == "sort":
             # slow for large arrays

--- a/pyflwdir/flwdir.py
+++ b/pyflwdir/flwdir.py
@@ -175,7 +175,7 @@ class Flwdir:
     def idxs_seq(self) -> np.ndarray:
         """Linear indices of valid cells ordered from down- to upstream."""
         if self._seq is None:
-            self.order_cells(method="sort")
+            self.order_cells(method="walk")
         return cast(np.ndarray, self._seq)
 
     @property
@@ -239,16 +239,16 @@ class Flwdir:
 
     ### SET/MODIFY PROPERTIES ###
 
-    def order_cells(self, method: Literal["sort", "walk"] = "sort") -> None:
+    def order_cells(self, method: Literal["sort", "walk"] = "walk") -> None:
         """Order cells from down- to upstream.
 
         Parameters
         ----------
-        method: {'sort', 'walk'}, optional
-            Method to order nodes, based on a "sorting" algorithm where nodes are
-            sorted based on their rank (might be slow for large arrays) or "walking"
-            algorithm where nodes are traced from down- to upstream (faster, but
-            holds the upstream cells of the whole network in memory)
+        method: {'walk', 'sort'}, optional
+            Method to order nodes: the default "walk" traces the nodes from down- to
+            upstream, holding the upstream cells of the whole network in memory in
+            compressed sparse row layout; "sort" sorts the nodes on their rank,
+            which is slower for large arrays.
         """
         if method == "sort":
             # slow for large arrays

--- a/pyflwdir/pyflwdir.py
+++ b/pyflwdir/pyflwdir.py
@@ -296,7 +296,7 @@ class FlwdirRaster(Flwdir):
     def idxs_seq(self) -> np.ndarray:
         """Linear indices of valid cells ordered from down- to upstream."""
         if self._seq is None:
-            self.order_cells(method="walk" if self.ftype != "nextxy" else "sort")
+            self.order_cells(method="walk")
         return cast(np.ndarray, self._seq)
 
     ### SET/MODIFY PROPERTIES ###

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -60,6 +60,29 @@ def test_downstream(test_data, flwdir, request):
         assert np.all(rank3[idxs1] == n_up)
 
 
+@pytest.mark.parametrize("test_data", ["test_data0", "test_data1", "test_data2"])
+def test_upstream_csr(test_data, request):
+    test_data = request.getfixturevalue(test_data)
+    idxs_ds, idxs_pit, seq, rank, mv = [p.copy() for p in test_data]
+    idxs_ds[rank == -1] = mv
+    n = idxs_ds.size
+    indptr, idxs_us = core.upstream_csr(idxs_ds, mv=mv)
+    # one slice per cell, one entry per upstream cell
+    assert indptr.size == n + 1
+    assert indptr[0] == 0
+    assert indptr[n] == idxs_us.size == seq.size - idxs_pit.size
+    assert np.all(np.diff(indptr.astype(np.int64)) >= 0)
+    # every entry drains into the cell whose slice it sits in
+    for idx0 in range(n):
+        for k in range(indptr[idx0], indptr[idx0 + 1]):
+            assert idxs_ds[idxs_us[k]] == idx0
+    # same upstream cells, in the same order, as the dense upstream matrix
+    idxs_us0 = core.upstream_matrix(idxs_ds, mv=mv)
+    for idx0 in range(n):
+        us0 = idxs_us0[idx0][idxs_us0[idx0] != mv]
+        assert np.array_equal(idxs_us[indptr[idx0] : indptr[idx0 + 1]], us0)
+
+
 @pytest.mark.parametrize(
     "test_data, flwdir", [("test_data0", "flwdir0"), ("test_data0", "flwdir0")]
 )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -83,6 +83,19 @@ def test_upstream_csr(test_data, request):
         assert np.array_equal(idxs_us[indptr[idx0] : indptr[idx0 + 1]], us0)
 
 
+def test_upstream_csr_high_fanin():
+    # more than 127 cells draining into one cell: upstream_count returns int8,
+    # which saturates, while the CSR index counts in the index dtype
+    n = 130
+    idxs_ds = np.full(n, n - 1, dtype=np.int32)
+    idxs_ds[n - 1] = n - 1  # pit
+    mv = np.int32(-1)
+    indptr, idxs_us = core.upstream_csr(idxs_ds, mv=mv)
+    assert indptr[n] == idxs_us.size == n - 1
+    seq = core.idxs_seq(idxs_ds, core.pit_indices(idxs_ds), mv)
+    assert seq.size == n
+
+
 @pytest.mark.parametrize(
     "test_data, flwdir", [("test_data0", "flwdir0"), ("test_data0", "flwdir0")]
 )

--- a/tests/test_pyflwdir.py
+++ b/tests/test_pyflwdir.py
@@ -431,8 +431,14 @@ def test_from_array_nextxy_self_pointing_cell_is_pit():
     nextx[0, 0], nexty[0, 0] = -9, -9  # a coded pit next to it
     flw = pyflwdir.from_array(np.stack([nextx, nexty]), ftype="nextxy")
     assert np.sort(flw.idxs_pit).tolist() == [0, 4]
+    seq_default = flw.idxs_seq.copy()  # the lazy default, i.e. the walk
     flw.order_cells(method="walk")
     seq_walk = flw.idxs_seq.copy()
+    assert np.array_equal(seq_default, seq_walk)
+    assert seq_walk.size == 9
     flw.order_cells(method="sort")
     assert np.array_equal(np.sort(seq_walk), np.sort(flw.idxs_seq))
-    assert seq_walk.size == 9
+    # every cell but the pits comes after its downstream cell
+    position = np.full(9, -1)
+    position[seq_walk] = np.arange(9)
+    assert np.all(position[flw.idxs_ds[seq_walk]] <= position[seq_walk])

--- a/tests/test_pyflwdir.py
+++ b/tests/test_pyflwdir.py
@@ -421,3 +421,18 @@ def test_dem(flw0):
     assert np.all(fldpln.flat[flw0.mask] == 1)
     with pytest.raises(ValueError, match="size does not match"):
         flw0.floodplains(np.ones((2, 1)))
+
+
+def test_from_array_nextxy_self_pointing_cell_is_pit():
+    # a nextxy cell whose next cell is itself is a pit, and the walk ordering
+    # starts from it like from the coded pits
+    nextx = np.full((3, 3), 2, dtype=np.int32)
+    nexty = np.full((3, 3), 2, dtype=np.int32)
+    nextx[0, 0], nexty[0, 0] = -9, -9  # a coded pit next to it
+    flw = pyflwdir.from_array(np.stack([nextx, nexty]), ftype="nextxy")
+    assert np.sort(flw.idxs_pit).tolist() == [0, 4]
+    flw.order_cells(method="walk")
+    seq_walk = flw.idxs_seq.copy()
+    flw.order_cells(method="sort")
+    assert np.array_equal(np.sort(seq_walk), np.sort(flw.idxs_seq))
+    assert seq_walk.size == 9


### PR DESCRIPTION
## Issue addressed
The first half of #114 (the issue also raises two further orderings, which stay
open there).

## Explanation
`core.idxs_seq` backs `order_cells(method="walk")`, the default `idxs_seq` path
of d8 and ldd rasters. It first builds `core.upstream_matrix`: a dense `(n, d)`
array of upstream cell indices, `d` being the largest number of upstream cells
of any one cell. The array is allocated for every cell of the raster, nodata
included, while only `e` of its entries carry a cell index, `e` being the number
of cells that drain into another cell. So most of it is the missing value, which
is the "uses more memory" in the `order_cells` docstring.

This adds `core.upstream_csr`, which holds the same upstream cells in compressed
sparse row layout: an `indptr` of `n + 1` offsets and one entry per upstream
cell, `n + 1 + e` values instead of `n * d`. `core.idxs_seq` reads its upstream
cells from it.

The traversal is unchanged, and each cell's upstream cells are kept sorted by
linear index exactly as `upstream_matrix` has them, so `idxs_seq` returns the
same array as before, element by element. `upstream_matrix` is untouched; after
this change it is no longer used inside the package, but whether to deprecate it
seemed yours to decide rather than mine.

The notebook in the issue writes out this ordering and three others in full and
runs the measurements below:
https://github.com/hellolulujiang/pyflwdir/blob/orderings/examples/ordering.ipynb

### Benchmark
`examples/rhine_d8.tif`, 682 x 997 = 679,954 cells of which 349,847 are in the
basin, `int32` indices, on my personal MacBook (an M1 Max) which was not
otherwise idle, so take the times as indicative; the sizes are what the two
functions allocate, read off their source, and do not depend on the machine:

|                        | build   | upstream cells |
|------------------------|--------:|---------------:|
| `upstream_matrix`, now | 7.1 ms  |        19.0 MB |
| `upstream_csr`         | 4.5 ms  |         4.1 MB |

The index accounts for all of it: `679954 * 7 * 4` bytes against
`(679954 + 1 + 349846) * 4`. The gap widens with the share of nodata, since the
dense array reserves `d` entries for cells with no upstream cell at all, and half
of this raster is outside the basin.

On a 1.33 billion cell window of MERIT Hydro at 3 arcsec the same arithmetic is
39.7 GiB against 7.2 GiB, and the build 28.4 s against 10.9 s.

The returned `idxs_seq` is identical element by element to the current one, on
this raster and on that one, the latter checked by hashing both.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed
- [x] Updated CHANGELOG.rst if needed

## Additional Notes
Two things worth flagging:

- `idxs_seq` casts indices to `np.intp` before arithmetic such as
  `indptr[idx0 + 1]`, because adding a signed literal to a `uint64` index
  promotes to float -- the same failure as #79. `_get_idxs_dtype` no longer
  returns `uint64`, but `Flwdir` still accepts a `uint64` array from the user.
- Reading the counts straight into the index array also removes a silent
  truncation: `upstream_count` returns `int8`, so a cell with more than 127
  upstream cells saturates it and the dense matrix comes out too narrow. On
  `main`, `idxs_seq` returns 1 cell of a 129 cell network in which 128 drain
  into one outlet; with this change it returns all 129. That cannot happen on a
  d8 raster, where at most 8 cells drain into one, but a `Flwdir` network from
  `from_dataframe` can reach it. A test covers it.
- The test suite runs with `NUMBA_DISABLE_JIT=1` (set in `conftest.py`), so the
  new test does not exercise the compiled code. I ran `upstream_csr` and
  `idxs_seq` compiled as well, for `int32`, `uint32`, `int64` and `uint64`
  indices, and checked the upstream cells of every cell against
  `upstream_matrix`. Happy to add that as a separate test if you want it in CI.