### PR TITLE
Fix/test with numba jit

### DIFF
--- a/pyflwdir/dem.py
+++ b/pyflwdir/dem.py
@@ -81,7 +81,7 @@ def fill_depressions(
 
     # initiate queue
     if idxs_pit is None:  # with edge cells
-        queued = gis_utils.get_edge(~done, structure=struct)
+        queued = gis_utils._get_edge(~done, struct)
         if elv_max is not None:
             queued = np.logical_and(queued, elevtn <= elv_max)
             if not np.any(queued):

--- a/pyflwdir/flwdir.py
+++ b/pyflwdir/flwdir.py
@@ -26,14 +26,30 @@ __all__ = ["Flwdir", "from_dataframe"]
 logger = logging.getLogger(__name__)
 
 
+def _ensure_supported_index_dtype(
+    idxs: np.ndarray | None, name: str
+) -> np.ndarray | None:
+    if idxs is not None and idxs.dtype == np.uint64:
+        uint64_mv = np.iinfo(np.uint64).max
+        int64_max = np.iinfo(np.int64).max
+        if np.any((idxs > int64_max) & (idxs != uint64_mv)):
+            raise ValueError(
+                f'"{name}" contains indices which cannot be represented as int64.'
+            )
+        idxs = idxs.astype(np.int64)
+    return idxs
+
+
 @njit(cache=True)
 def get_loc_idx(idxs: np.ndarray, idxs_ds: np.ndarray) -> np.ndarray:
     """Get linear indices of downstream cells."""
     idx_map = {idx: i for i, idx in enumerate(idxs)}
     # return i if idx_ds not in idx_map, i.e. idx is a pit
-    idxs_ds0 = np.empty_like(idxs, dtype=idxs.dtype)
+    idxs_ds0 = np.empty(idxs.size, dtype=np.intp)
     for i, idx_ds in enumerate(idxs_ds):
-        idxs_ds0[i] = idx_map.get(idx_ds, i)
+        idxs_ds0[i] = i
+        if idx_ds in idx_map:
+            idxs_ds0[i] = idx_map[idx_ds]
     return idxs_ds0
 
 
@@ -97,17 +113,19 @@ class Flwdir:
         self.shape: Any = self.size
 
         # data
+        idxs_ds = cast(np.ndarray, _ensure_supported_index_dtype(idxs_ds, "idxs_ds"))
+        idxs_pit = _ensure_supported_index_dtype(idxs_pit, "idxs_pit")
+        idxs_outlet = _ensure_supported_index_dtype(idxs_outlet, "idxs_outlet")
+        idxs_seq = _ensure_supported_index_dtype(idxs_seq, "idxs_seq")
         self._idxs_ds = idxs_ds
         self._pit = idxs_pit
         self.idxs_outlet = idxs_outlet
         self._seq = idxs_seq
         self._nnodes = nnodes
-        # either -1 for int, 4294967295 for uint32, or 18446744073709551615 for uint64
+        # either -1 for signed integers or 4294967295 for uint32
         self._mv: Any = core._mv
         if idxs_ds.dtype == np.uint32:
             self._mv = np.uint32(self._mv)
-        if idxs_ds.dtype == np.uint64:
-            self._mv = np.uint64(self._mv)
 
         # set placeholders only used if cache if True
         self.cache = cache

--- a/pyflwdir/gis_utils.py
+++ b/pyflwdir/gis_utils.py
@@ -141,12 +141,8 @@ def get_edge(a: np.ndarray, structure: np.ndarray | None = None) -> np.ndarray:
         Boolean array edge cells.
     """
     if structure is None:
-        struct = np.ones((3, 3), dtype=bool)
-    elif (
-        not isinstance(structure, np.ndarray)
-        or structure.shape != (3, 3)
-        or structure.dtype != bool
-    ):
+        struct = np.ones((3, 3), dtype=np.bool_)
+    elif structure.shape != (3, 3):
         raise ValueError("structure must be a 3x3 boolean array")
     else:
         struct = structure

--- a/pyflwdir/gis_utils.py
+++ b/pyflwdir/gis_utils.py
@@ -123,7 +123,6 @@ def spread2d(
     return out, src, dst
 
 
-@njit(cache=True)
 def get_edge(a: np.ndarray, structure: np.ndarray | None = None) -> np.ndarray:
     """Get edge of valid cells.
 
@@ -142,10 +141,19 @@ def get_edge(a: np.ndarray, structure: np.ndarray | None = None) -> np.ndarray:
     """
     if structure is None:
         struct = np.ones((3, 3), dtype=np.bool_)
-    elif structure.shape != (3, 3):
+    elif (
+        not isinstance(structure, np.ndarray)
+        or structure.shape != (3, 3)
+        or structure.dtype != bool
+    ):
         raise ValueError("structure must be a 3x3 boolean array")
     else:
         struct = structure
+    return _get_edge(a, struct)
+
+
+@njit(cache=True)
+def _get_edge(a: np.ndarray, struct: np.ndarray) -> np.ndarray:
     s = np.where(struct.ravel())[0]
     edge = a.copy()
     nrow, ncol = a.shape

--- a/pyflwdir/gis_utils.py
+++ b/pyflwdir/gis_utils.py
@@ -173,7 +173,7 @@ def transform_from_origin(
     the coordinates of its upper left corner `west`, `north` and pixel
     sizes `xsize`, `ysize`.
     """
-    return Affine.translation(west, north) * Affine.scale(xsize, -ysize)
+    return Affine(xsize, 0.0, west, 0.0, -ysize, north)
 
 
 def transform_from_bounds(
@@ -189,8 +189,13 @@ def transform_from_bounds(
     its bounds `west`, `south`, `east`, `north` and its `width` and
     `height` in number of pixels.
     """
-    return Affine.translation(west, north) * Affine.scale(
-        (east - west) / width, (south - north) / height
+    return Affine(
+        (east - west) / width,
+        0.0,
+        west,
+        0.0,
+        (south - north) / height,
+        north,
     )
 
 
@@ -202,7 +207,8 @@ def array_bounds(
     its height, width, and an affine transform.
     """
     w, n = transform.xoff, transform.yoff
-    e, s = transform * (width, height)
+    e = transform.a * width + transform.b * height + transform.c
+    s = transform.d * width + transform.e * height + transform.f
     return w, s, e, n
 
 
@@ -250,7 +256,8 @@ def xy(
     else:
         raise ValueError("Invalid offset")
 
-    xs, ys = transform * transform.translation(coff, roff) * (cols, rows)
+    xs = transform.a * (cols + coff) + transform.b * (rows + roff) + transform.c
+    ys = transform.d * (cols + coff) + transform.e * (rows + roff) + transform.f
     return xs, ys
 
 
@@ -293,7 +300,8 @@ def rowcol(
     else:
         eps = 10.0**-precision * (1.0 - 2.0 * op(0.1))
     invtransform = ~transform
-    fcols, frows = invtransform * (xs + eps, ys - eps)
+    fcols = invtransform.a * (xs + eps) + invtransform.b * (ys - eps) + invtransform.c
+    frows = invtransform.d * (xs + eps) + invtransform.e * (ys - eps) + invtransform.f
     cols, rows = op(fcols).astype(int), op(frows).astype(int)
     return rows, cols
 
@@ -405,8 +413,8 @@ def affine_to_coords(
     x, y coordinate arrays : tuple of ndarray of float
     """
     height, width = shape
-    x_coords, _ = affine * (np.arange(width) + 0.5, np.zeros(width) + 0.5)
-    _, y_coords = affine * (np.zeros(height) + 0.5, np.arange(height) + 0.5)
+    x_coords = affine.a * (np.arange(width) + 0.5) + affine.b * 0.5 + affine.c
+    y_coords = affine.d * 0.5 + affine.e * (np.arange(height) + 0.5) + affine.f
     return x_coords, y_coords
 
 

--- a/pyflwdir/streams.py
+++ b/pyflwdir/streams.py
@@ -288,7 +288,6 @@ def strahler_order(
     return strord
 
 
-@njit(cache=True)
 def stream_distance(
     idxs_ds: np.ndarray,
     seq: np.ndarray,
@@ -320,18 +319,44 @@ def stream_distance(
     1D array of float
         distance to outlet or next downstream True cell
     """
-    mv = -9999.0
-    dist = np.full(idxs_ds.size, mv, dtype=np.float32 if real_length else np.int32)
-    dist[seq] = 0  # initialize valid cells with zero length
-    d = 1
+    if real_length:
+        return _stream_distance_real(idxs_ds, seq, ncol, mask, latlon, transform)
+    return _stream_distance_cell(idxs_ds, seq, mask)
+
+
+@njit(cache=True)
+def _stream_distance_real(
+    idxs_ds: np.ndarray,
+    seq: np.ndarray,
+    ncol: int,
+    mask: np.ndarray | None = None,
+    latlon: bool = False,
+    transform: np.ndarray = gis_utils._IDENTITY,
+) -> np.ndarray:
+    dist = np.full(idxs_ds.size, -9999.0, dtype=np.float32)
+    dist[seq] = 0
     for idx0 in seq:  # down- to upstream
         idx_ds = idxs_ds[idx0]
         # sum distances; skip if at pit or mask is True
         if idx0 == idx_ds or (mask is not None and mask[idx0]):
             continue
-        if real_length:
-            d = gis_utils.distance(idx0, idx_ds, ncol, latlon, transform)
+        d = gis_utils.distance(idx0, idx_ds, ncol, latlon, transform)
         dist[idx0] = dist[idx_ds] + d
+    return dist
+
+
+@njit(cache=True)
+def _stream_distance_cell(
+    idxs_ds: np.ndarray, seq: np.ndarray, mask: np.ndarray | None = None
+) -> np.ndarray:
+    dist = np.full(idxs_ds.size, -9999, dtype=np.int32)
+    dist[seq] = 0
+    for idx0 in seq:  # down- to upstream
+        idx_ds = idxs_ds[idx0]
+        # sum distances; skip if at pit or mask is True
+        if idx0 == idx_ds or (mask is not None and mask[idx0]):
+            continue
+        dist[idx0] = dist[idx_ds] + 1
     return dist
 
 

--- a/pyflwdir/subgrid.py
+++ b/pyflwdir/subgrid.py
@@ -101,7 +101,6 @@ def ucat_area(
     return ucatch_map, ucatch_are
 
 
-@njit(cache=True)
 def ucat_volume(
     idxs_out: np.ndarray,
     idxs_ds: np.ndarray,
@@ -133,6 +132,19 @@ def ucat_volume(
     """
     if depths is None:
         depths = np.arange(0.5, 3.0, 0.5, dtype=np.float32)
+    return _ucat_volume(idxs_out, idxs_ds, seq, hand, area, depths, mv=mv)
+
+
+@njit(cache=True)
+def _ucat_volume(
+    idxs_out: np.ndarray,
+    idxs_ds: np.ndarray,
+    seq: np.ndarray,
+    hand: np.ndarray,
+    area: np.ndarray,
+    depths: np.ndarray,
+    mv: int = _mv,
+) -> tuple[np.ndarray, np.ndarray]:
     # initialize outputs
     ucatch_map = np.full(idxs_ds.size, 0, dtype=idxs_ds.dtype)
     fldpln_vol = np.full((depths.size, idxs_out.size), -9999, dtype=depths.dtype)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,7 @@ exclude = ["docs", "notebooks", "envs", "tests", "binder", ".github"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-filterwarnings = [
-    "error",
-    "ignore::PendingDeprecationWarning:affine.*",
-]
+filterwarnings = ["error"]
 
 [tool.mypy]
 files = ["pyflwdir"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ exclude = ["docs", "notebooks", "envs", "tests", "binder", ".github"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 filterwarnings = [
+    "error",
     "ignore::PendingDeprecationWarning:affine.*",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,9 @@ exclude = ["docs", "notebooks", "envs", "tests", "binder", ".github"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-filterwarnings = ["error"]
+filterwarnings = [
+    "ignore::PendingDeprecationWarning:affine.*",
+]
 
 [tool.mypy]
 files = ["pyflwdir"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,8 @@ import os
 import numpy as np
 import pytest
 
-from pyflwdir import core, core_d8, core_nextxy  # noqa: E402
-from pyflwdir.pyflwdir import FlwdirRaster, from_dem  # noqa: E402
+from pyflwdir import core, core_d8, core_nextxy
+from pyflwdir.pyflwdir import FlwdirRaster, from_dem
 
 
 @pytest.fixture(scope="session")
@@ -86,14 +86,14 @@ def flwdir2():
 
 @pytest.fixture(scope="session")
 def flwdir2_idxs(flwdir2):
-    idxs_ds2, idxs_pit2, _ = core_d8.from_array(flwdir2, dtype=np.uint64)
+    idxs_ds2, idxs_pit2, _ = core_d8.from_array(flwdir2, dtype=np.int64)
     return idxs_ds2, idxs_pit2
 
 
 @pytest.fixture(scope="session")
 def flwdir2_rank(flwdir2_idxs):
     idxs_ds2, _ = flwdir2_idxs
-    rank2, n2 = core.rank(idxs_ds2, mv=np.uint64(core._mv))
+    rank2, n2 = core.rank(idxs_ds2, mv=core._mv)
     seq2 = np.argsort(rank2)[-n2:]
     return rank2, n2, seq2
 
@@ -102,7 +102,7 @@ def flwdir2_rank(flwdir2_idxs):
 def test_data2(flwdir2_idxs, flwdir2_rank):
     rank2, _, seq2 = flwdir2_rank
     idxs_ds2, idxs_pit2 = flwdir2_idxs
-    return idxs_ds2, idxs_pit2, seq2, rank2, np.uint64(core._mv)
+    return idxs_ds2, idxs_pit2, seq2, rank2, core._mv
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,6 @@ import os
 import numpy as np
 import pytest
 
-# uncomment for debugging tests
-os.environ["NUMBA_DISABLE_JIT"] = "1"
-
 from pyflwdir import core, core_d8, core_nextxy  # noqa: E402
 from pyflwdir.pyflwdir import FlwdirRaster, from_dem  # noqa: E402
 

--- a/tests/test_flwdir.py
+++ b/tests/test_flwdir.py
@@ -35,4 +35,4 @@ def test_from_dataframe(data):
     idxs_ds0 = get_loc_idx(idx.astype(np.uint64), idx_ds.astype(np.uint64))
     flwdir = Flwdir(idxs_ds=idxs_ds0)
     assert np.all(flwdir.rank == rank)
-    assert flwdir._mv == 18446744073709551615
+    assert flwdir._mv == -1

--- a/tests/test_flwdir.py
+++ b/tests/test_flwdir.py
@@ -36,3 +36,30 @@ def test_from_dataframe(data):
     flwdir = Flwdir(idxs_ds=idxs_ds0)
     assert np.all(flwdir.rank == rank)
     assert flwdir._mv == -1
+
+
+def test_flwdir_uint64_indices_are_normalized(data):
+    _, _, idxs_ds, rank = data
+    idxs_pit = np.array([0, 11], dtype=np.uint64)
+    idxs_seq = np.argsort(rank).astype(np.uint64)
+
+    flwdir = Flwdir(
+        idxs_ds=idxs_ds.astype(np.uint64),
+        idxs_pit=idxs_pit,
+        idxs_outlet=idxs_pit,
+        idxs_seq=idxs_seq,
+    )
+
+    assert flwdir.idxs_ds.dtype == np.int64
+    assert flwdir.idxs_pit.dtype == np.int64
+    assert flwdir.idxs_outlet.dtype == np.int64
+    assert flwdir.idxs_seq.dtype == np.int64
+    assert flwdir._mv == -1
+    assert np.all(flwdir.rank == rank)
+
+
+def test_flwdir_uint64_indices_larger_than_int64_raise():
+    idxs_ds = np.array([0, np.iinfo(np.int64).max + 1], dtype=np.uint64)
+
+    with pytest.raises(ValueError, match="cannot be represented as int64"):
+        Flwdir(idxs_ds=idxs_ds)

--- a/tests/test_gis_utils.py
+++ b/tests/test_gis_utils.py
@@ -239,6 +239,19 @@ def test_edge():
     assert np.all(gis.get_edge(a, structure=d4) == b)
 
 
+@pytest.mark.parametrize(
+    "structure",
+    [
+        [[True] * 3] * 3,
+        np.ones((2, 2), dtype=bool),
+        np.ones((3, 3), dtype=np.uint8),
+    ],
+)
+def test_edge_structure_validation(structure):
+    with pytest.raises(ValueError, match="structure must be a 3x3 boolean array"):
+        gis.get_edge(np.ones((5, 5), dtype=bool), structure=structure)
+
+
 def test_spread():
     a = np.zeros((5, 5))
     a[2, 2] = 1

--- a/tests/test_gis_utils.py
+++ b/tests/test_gis_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for the pyflwdir.gis_utils module."""
 
 import numpy as np
@@ -22,6 +21,75 @@ prof = {
     "transform": Affine(1 / 1200.0, 0.0, -10.5, 0.0, -1 / 1200.0, 55.5),
 }
 
+TRANSFORM_CASES = [
+    pytest.param(
+        (3, 4),
+        Affine(1.0, 0.0, 100.0, 0.0, -2.0, 50.0),
+        (100.0, 44.0, 104.0, 50.0),
+        {
+            "ul": (100.0, 50.0),
+            "ur": (101.0, 50.0),
+            "ll": (100.0, 48.0),
+            "lr": (101.0, 48.0),
+            "center": (100.5, 49.0),
+        },
+        np.array([100.5, 101.5, 102.5, 103.5]),
+        np.array([49.0, 47.0, 45.0]),
+        id="north-up",
+    ),
+    pytest.param(
+        (3, 4),
+        Affine(1.25, 0.0, -3.0, 0.0, 2.5, 4.0),
+        (-3.0, 11.5, 2.0, 4.0),
+        {
+            "ul": (-3.0, 4.0),
+            "ur": (-1.75, 4.0),
+            "ll": (-3.0, 6.5),
+            "lr": (-1.75, 6.5),
+            "center": (-2.375, 5.25),
+        },
+        np.array([-2.375, -1.125, 0.125, 1.375]),
+        np.array([5.25, 7.75, 10.25]),
+        id="south-up",
+    ),
+    pytest.param(
+        (3, 4),
+        Affine(2.0, 0.25, 10.0, 0.5, -3.0, 20.0),
+        (10.0, 13.0, 18.75, 20.0),
+        {
+            "ul": (10.0, 20.0),
+            "ur": (12.0, 20.5),
+            "ll": (10.25, 17.0),
+            "lr": (12.25, 17.5),
+            "center": (11.125, 18.75),
+        },
+        np.array([11.125, 13.125, 15.125, 17.125]),
+        np.array([18.75, 15.75, 12.75]),
+        id="rotated-north-up",
+    ),
+    pytest.param(
+        (3, 4),
+        Affine(1.5, -0.25, -5.0, -0.4, 2.0, 7.0),
+        (-5.0, 11.4, 0.25, 7.0),
+        {
+            "ul": (-5.0, 7.0),
+            "ur": (-3.5, 6.6),
+            "ll": (-5.25, 9.0),
+            "lr": (-3.75, 8.6),
+            "center": (-4.375, 7.8),
+        },
+        np.array([-4.375, -2.875, -1.375, 0.125]),
+        np.array([7.8, 9.8, 11.8]),
+        id="rotated-south-up",
+    ),
+]
+
+
+def _transform_xy(transform, cols, rows):
+    xs = transform.a * cols + transform.b * rows + transform.c
+    ys = transform.d * cols + transform.e * rows + transform.f
+    return xs, ys
+
 
 def test_from_origin():
     w, _, _, n = prof["bounds"]
@@ -35,30 +103,33 @@ def test_from_bounds():
     assert [round(v, 7) for v in tr] == [round(v, 7) for v in prof["transform"]]
 
 
-def test_array_bounds():
-    bounds0 = np.asarray(prof["bounds"])
-    bounds = gis.array_bounds(prof["height"], prof["width"], prof["transform"])
-    assert np.all(bounds0 == np.asarray(bounds).round(7))
+@pytest.mark.parametrize(
+    "shape, transform, expected_bounds, _, __, ___", TRANSFORM_CASES
+)
+def test_array_bounds(shape, transform, expected_bounds, _, __, ___):
+    height, width = shape
+    bounds = gis.array_bounds(height, width, transform)
+    assert np.allclose(bounds, expected_bounds)
 
 
-def test_xy():
-    aff = prof["transform"]
-    ul_x, ul_y = aff * (0, 0)
-    xoff = aff.a
-    yoff = aff.e
-    assert gis.xy(aff, 0, 0, offset="ul") == (ul_x, ul_y)
-    assert gis.xy(aff, 0, 0, offset="ur") == (ul_x + xoff, ul_y)
-    assert gis.xy(aff, 0, 0, offset="ll") == (ul_x, ul_y + yoff)
-    expected = (ul_x + xoff, ul_y + yoff)
-    assert gis.xy(aff, 0, 0, offset="lr") == expected
-    expected = (ul_x + xoff / 2, ul_y + yoff / 2)
-    assert gis.xy(aff, 0, 0, offset="center") == expected
+@pytest.mark.parametrize(
+    "shape, transform, _, expected_offsets, __, ___", TRANSFORM_CASES
+)
+def test_xy(shape, transform, _, expected_offsets, __, ___):
+    for offset, expected in expected_offsets.items():
+        assert gis.xy(transform, 0, 0, offset=offset) == expected
     assert (
-        gis.xy(aff, 0, 0, offset="lr")
-        == gis.xy(aff, 0, 1, offset="ll")
-        == gis.xy(aff, 1, 1, offset="ul")
-        == gis.xy(aff, 1, 0, offset="ur")
+        gis.xy(transform, 0, 0, offset="lr")
+        == gis.xy(transform, 0, 1, offset="ll")
+        == gis.xy(transform, 1, 1, offset="ul")
+        == gis.xy(transform, 1, 0, offset="ur")
     )
+
+    rows, cols = np.indices(shape)
+    xs, ys = gis.xy(transform, rows, cols)
+    expected = _transform_xy(transform, cols + 0.5, rows + 0.5)
+    assert np.allclose(xs, expected[0])
+    assert np.allclose(ys, expected[1])
 
 
 def test_rowcol():
@@ -70,34 +141,45 @@ def test_rowcol():
     assert gis.rowcol(aff, left, bottom) == (-bottom, left)
 
 
-def test_idxs_to_coords():
-    shape = (10, 8)
+@pytest.mark.parametrize("shape, transform, _, __, ___, ____", TRANSFORM_CASES)
+def test_rowcol_transform_cases(shape, transform, _, __, ___, ____):
+    rows, cols = np.indices(shape)
+    xs, ys = _transform_xy(transform, cols + 0.5, rows + 0.5)
+    rows1, cols1 = gis.rowcol(transform, xs, ys)
+    assert np.all(rows1 == rows)
+    assert np.all(cols1 == cols)
+
+
+@pytest.mark.parametrize("shape, transform, _, __, ___, ____", TRANSFORM_CASES)
+def test_idxs_to_coords(shape, transform, _, __, ___, ____):
     idxs = np.arange(shape[0] * shape[1]).reshape(shape)
-    transform = gis.Affine(1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
     xs, ys = gis.idxs_to_coords(idxs, transform, shape)
-    assert np.all(ys == (np.arange(shape[0]) + 0.5)[:, None])
-    assert np.all(xs == np.arange(shape[1]) + 0.5)
+    rows, cols = np.indices(shape)
+    expected = _transform_xy(transform, cols + 0.5, rows + 0.5)
+    assert np.allclose(xs, expected[0])
+    assert np.allclose(ys, expected[1])
     with pytest.raises(IndexError):
         gis.idxs_to_coords(np.array([-1]), transform, shape)
 
 
-def test_coords_to_idxs():
-    shape = (10, 8)
+@pytest.mark.parametrize("shape, transform, _, __, ___, ____", TRANSFORM_CASES)
+def test_coords_to_idxs(shape, transform, _, __, ___, ____):
     idxs0 = np.arange(shape[0] * shape[1])
-    transform = gis.Affine(1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
-    xs, ys = np.meshgrid(np.arange(shape[1]) + 0.5, np.arange(shape[0]) + 0.5)
+    rows, cols = np.indices(shape)
+    xs, ys = _transform_xy(transform, cols + 0.5, rows + 0.5)
     idxs = gis.coords_to_idxs(xs, ys, transform, shape)
     assert np.all(idxs.ravel() == idxs0)
     with pytest.raises(IndexError):
         gis.coords_to_idxs(ys, xs, transform, shape)
 
 
-def test_affine_to_coords():
-    shape = (10, 8)
-    transform = gis.Affine(1.0, 0.0, 0.0, 0.0, 1.0, 0.0)
+@pytest.mark.parametrize(
+    "shape, transform, _, __, expected_xcoords, expected_ycoords", TRANSFORM_CASES
+)
+def test_affine_to_coords(shape, transform, _, __, expected_xcoords, expected_ycoords):
     xs, ys = gis.affine_to_coords(transform, shape)
-    assert np.all(ys == np.arange(shape[0]) + 0.5)
-    assert np.all(xs == np.arange(shape[1]) + 0.5)
+    assert np.allclose(xs, expected_xcoords)
+    assert np.allclose(ys, expected_ycoords)
 
 
 def test_reggrid_dx():


### PR DESCRIPTION
## Summary

This PR fixes the Numba JIT test failures and removes the remaining `NumbaTypeSafetyWarning` warnings when running the suite with JIT enabled.

## Changes

- Normalize direct `uint64` index inputs in `Flwdir`
  - `Flwdir.__init__()` now converts user-supplied `uint64` index arrays to signed `int64`.
  - Applies to `idxs_ds`, `idxs_pit`, `idxs_outlet`, and `idxs_seq`.
  - Removes the internal `uint64` missing-value path; `uint64` is treated as compatibility input, not an internal dtype.

- Use native index dtype for local dataframe index mapping
  - `get_loc_idx()` now returns an `np.intp` array.
  - Avoids the Numba warning caused by `dict.get(..., default)` type inference.

- Make `gis_utils.get_edge()` compatible with Numba nopython mode
  - Replaces `dtype=bool` with `np.bool_`.
  - Removes unsupported runtime type and dtype checks inside the jitted function.

- Make `streams.stream_distance()` compatible with Numba nopython mode
  - Splits the implementation into a Python dispatcher plus two jitted helpers:
    - one for real-length distances returning `float32`
    - one for cell-count distances returning `int32`
  - Avoids Numba trying to unify different return dtypes from one compiled function.

- Make `subgrid.ucat_volume()` compatible with Numba nopython mode
  - Splits optional `depths=None` handling out of the jitted implementation.
  - Keeps the compiled helper on a single concrete `depths` array dtype.

- Update test fixtures and expectations
  - `flwdir2` test fixture now uses supported `int64` indices instead of `uint64`.
  - Updated direct `uint64` `Flwdir` test expectation to signed missing value `-1`.
  - Removed stale `# noqa: E402` directives from `tests/conftest.py`.

## Validation

- `pixi run -e test-py312 test`
  - `90 passed`
  - no warning summary

- `pixi run lint`
  - passed

- `git diff --check`
  - passed